### PR TITLE
Move forward to wx 2.8 compatibility

### DIFF
--- a/_gui/__init__.py
+++ b/_gui/__init__.py
@@ -1,0 +1,2 @@
+import wx
+RUMMAGE_USED_OLD_WX = (float(wx.__version__[0:3]) < 2.9)

--- a/_gui/autocomplete_combo.py
+++ b/_gui/autocomplete_combo.py
@@ -14,6 +14,8 @@ import wx
 import sys
 from wx.combo import ComboPopup, ComboCtrl
 
+from . import RUMMAGE_USED_OLD_WX
+
 class AutoCompleteCombo(ComboCtrl):
     def __init__(self, parent, choices=[], load_last=False, changed_callback=None):
         """
@@ -35,7 +37,8 @@ class AutoCompleteCombo(ComboCtrl):
         self.Bind(wx.EVT_KEY_DOWN, self.on_key_down)
         self.Bind(wx.EVT_CHAR, self.on_char)
         self.Bind(wx.EVT_SET_FOCUS, self.on_focus)
-        self.Bind(wx.EVT_COMBOBOX_CLOSEUP, self.on_dismiss)
+        if not RUMMAGE_USED_OLD_WX:
+            self.Bind(wx.EVT_COMBOBOX_CLOSEUP, self.on_dismiss)
         self.Bind(wx.EVT_TEXT, self.on_text_change)
 
         # Add choices

--- a/_gui/notify.py
+++ b/_gui/notify.py
@@ -48,6 +48,7 @@ if _PLATFORM == "osx":
     NSSound = c_void_p(objc.objc_getClass('NSSound'))
     NSAutoreleasePool = c_void_p(objc.objc_getClass('NSAutoreleasePool'))
 
+from . import RUMMAGE_USED_OLD_WX
 
 GROWL_ICON = None
 GROWL_ENABLED = False
@@ -195,8 +196,19 @@ except:
             # Play sound if desired
             play_alert()
 
+if RUMMAGE_USED_OLD_WX:
+    class __NotificationMessage(object):
+        def Show(self):
+            print 'Unsupported in wx < 2.9 call wx.NotificationMessage.Show'
 
-class Notify(wx.NotificationMessage):
+        def SetFlags(self, *args, **kwargs):
+            print 'Unsupported in wx < 2.9 wx.NotificationMessage.SetFlags called'
+else:
+    class __NotificationMessage(wx.NotificationMessage):
+        pass
+
+
+class Notify(__NotificationMessage):
     def __init__(self, *args, **kwargs):
         """
         Setup Notify object


### PR DESCRIPTION
Currently Rummage is basing on wx 2.9 version. But current stable branch of wx is 2.8. To ease a packaging for most recent Linux distributions it's better to have 2.8 compatible version. My commit allows to run Rummage under wx 2.8 and should not break somehow 2.9 version. Will happy to see it in upstream)
So under ubuntu installation will probably have only one external depency: python-wxgtk2.8
