### PR TITLE
Move to flake8 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     env: TOXENV=py35-unittests
   - python: 3.6
     env: TOXENV=py36-unittests
-  - python: 2.7
+  - python: 3.6
     env: TOXENV=lint
   - python: 2.7
     env: TOXENV=documents

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,5 @@
-flake8>=2,<3
+flake8
 flake8-docstrings
-flake8-putty
 pep8-naming
+flake8-mutable
+flake8-builtins

--- a/rummage/lib/__version__.py
+++ b/rummage/lib/__version__.py
@@ -35,4 +35,5 @@ def _version():
 
     return ''.join((main, prerel, postrel))
 
+
 version = _version()

--- a/rummage/lib/gui/actions/export_html.py
+++ b/rummage/lib/gui/actions/export_html.py
@@ -34,6 +34,7 @@ def html_encode(text):
         )
     )
 
+
 HTML_HEADER = '''<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>

--- a/rummage/lib/gui/app/custom_app.py
+++ b/rummage/lib/gui/app/custom_app.py
@@ -398,12 +398,15 @@ class PipeApp(CustomApp):
 class DebugFrameExtender(object):
     """Extend frame with debugger."""
 
-    def set_keybindings(self, keybindings=[], debug_event=None):
+    def set_keybindings(self, keybindings=None, debug_event=None):
         """
         Method to easily set key bindings.
 
         Also sets up debug keybindings and events.
         """
+
+        if keybindings is None:
+            keybindings = []
 
         # Create keybinding to open debug console, bind debug console to ctrl/cmd + ` depending on platform
         # if an event is passed in.

--- a/rummage/lib/gui/settings/__init__.py
+++ b/rummage/lib/gui/settings/__init__.py
@@ -712,8 +712,11 @@ class Settings(object):
         cls.save_settings()
 
     @classmethod
-    def get_history_record_count(cls, history_types=[]):
+    def get_history_record_count(cls, history_types=None):
         """Get number of history items saved."""
+
+        if history_types is None:
+            history_types = []
 
         cls.reload_settings()
         count = 0
@@ -722,8 +725,11 @@ class Settings(object):
         return count
 
     @classmethod
-    def clear_history_records(cls, history_types=[]):
+    def clear_history_records(cls, history_types=None):
         """Clear history types."""
+
+        if history_types is None:
+            history_types = []
 
         cls.reload_settings()
         for h in history_types:

--- a/rummage/lib/util/__init__.py
+++ b/rummage/lib/util/__init__.py
@@ -20,11 +20,11 @@ if PY3:
     string_type = str
     ustr = str
     bstr = bytes
-    CommonBrokenPipeError = BrokenPipeError  # noqa
+    CommonBrokenPipeError = BrokenPipeError  # noqa F821
 else:
-    string_type = basestring
-    ustr = unicode
-    bstr = str
+    string_type = basestring  # noqa F821
+    ustr = unicode  # noqa F821
+    bstr = str  # noqa F821
 
     class CommonBrokenPipeError(Exception):
         """
@@ -124,7 +124,7 @@ def to_unicode_argv():
             if argc.value > 0:
                 # Remove Python executable and commands if present
                 start = argc.value - len(sys.argv)
-                args = [argv[i] for i in xrange(start, argc.value)]
+                args = [argv[i] for i in xrange(start, argc.value)]  # noqa F821
         else:
             cli_encoding = sys.stdin.encoding or locale.getpreferredencoding()
             args = [arg.decode(cli_encoding) for arg in sys.argv if isinstance(arg, bstr)]

--- a/rummage/lib/util/win_subprocess.py
+++ b/rummage/lib/util/win_subprocess.py
@@ -1,5 +1,5 @@
 """Created by @vaab at https://gist.github.com/vaab/2ad7051fc193167f15f85ef573e54eb9."""
-## issue: https://bugs.python.org/issue19264
+# issue: https://bugs.python.org/issue19264
 import os
 import ctypes
 import subprocess
@@ -7,9 +7,9 @@ import _subprocess
 from ctypes import byref, windll, c_char_p, c_wchar_p, c_void_p, Structure, sizeof, c_wchar, WinError
 from ctypes.wintypes import BYTE, WORD, LPWSTR, BOOL, DWORD, LPVOID, HANDLE
 
-##
-## Types
-##
+#
+# Types
+#
 
 CREATE_UNICODE_ENVIRONMENT = 0x00000400
 LPCTSTR = c_char_p
@@ -22,16 +22,26 @@ class STARTUPINFOW(Structure):
     """Startup info."""
 
     _fields_ = [
-        ("cb",              DWORD),  ("lpReserved",    LPWSTR),
-        ("lpDesktop",       LPWSTR), ("lpTitle",       LPWSTR),
-        ("dwX",             DWORD),  ("dwY",           DWORD),
-        ("dwXSize",         DWORD),  ("dwYSize",       DWORD),
-        ("dwXCountChars",   DWORD),  ("dwYCountChars", DWORD),
-        ("dwFillAtrribute", DWORD),  ("dwFlags",       DWORD),
-        ("wShowWindow",     WORD),   ("cbReserved2",   WORD),
-        ("lpReserved2",     LPBYTE), ("hStdInput",     HANDLE),
-        ("hStdOutput",      HANDLE), ("hStdError",     HANDLE),
+        ("cb", DWORD),
+        ("lpReserved", LPWSTR),
+        ("lpDesktop", LPWSTR),
+        ("lpTitle", LPWSTR),
+        ("dwX", DWORD),
+        ("dwY", DWORD),
+        ("dwXSize", DWORD),
+        ("dwYSize", DWORD),
+        ("dwXCountChars", DWORD),
+        ("dwYCountChars", DWORD),
+        ("dwFillAtrribute", DWORD),
+        ("dwFlags", DWORD),
+        ("wShowWindow", WORD),
+        ("cbReserved2", WORD),
+        ("lpReserved2", LPBYTE),
+        ("hStdInput", HANDLE),
+        ("hStdOutput", HANDLE),
+        ("hStdError", HANDLE),
     ]
+
 
 LPSTARTUPINFOW = ctypes.POINTER(STARTUPINFOW)
 
@@ -40,9 +50,12 @@ class PROCESS_INFORMATION(Structure):
     """Process info."""
 
     _fields_ = [
-        ("hProcess",         HANDLE), ("hThread",          HANDLE),
-        ("dwProcessId",      DWORD),  ("dwThreadId",       DWORD),
+        ("hProcess", HANDLE),
+        ("hThread", HANDLE),
+        ("dwProcessId", DWORD),
+        ("dwThreadId", DWORD),
     ]
+
 
 LPPROCESS_INFORMATION = ctypes.POINTER(PROCESS_INFORMATION)
 
@@ -78,9 +91,9 @@ CreateProcessW.argtypes = [
 CreateProcessW.restype = BOOL
 
 
-##
-## Patched functions/classes
-##
+#
+# Patched functions/classes
+#
 
 def CreateProcess(executable, args, _p_attr, _t_attr,
                   inherit_handles, creation_flags, env, cwd,
@@ -95,7 +108,7 @@ def CreateProcess(executable, args, _p_attr, _t_attr,
         dwFlags=startup_info.dwFlags,
         wShowWindow=startup_info.wShowWindow,
         cb=sizeof(STARTUPINFOW),
-        ## XXXvlab: not sure of the casting here to ints.
+        # XXXvlab: not sure of the casting here to ints.
         hStdInput=int(startup_info.hStdInput),
         hStdOutput=int(startup_info.hStdOutput),
         hStdError=int(startup_info.hStdError),
@@ -103,10 +116,10 @@ def CreateProcess(executable, args, _p_attr, _t_attr,
 
     wenv = None
     if env is not None:
-        ## LPCWSTR seems to be c_wchar_p, so let's say CWSTR is c_wchar
-        env = (unicode("").join([
-            unicode("%s=%s\0") % (k, v)
-            for k, v in env.items()])) + unicode("\0")
+        # LPCWSTR seems to be c_wchar_p, so let's say CWSTR is c_wchar
+        env = (unicode("").join([  # noqa F821
+            unicode("%s=%s\0") % (k, v)  # noqa F821
+            for k, v in env.items()])) + unicode("\0")  # noqa F821
         wenv = (c_wchar * len(env))()
         wenv.value = env
 
@@ -147,12 +160,12 @@ class Popen(subprocess.Popen):
         if shell:
             startupinfo.dwFlags |= _subprocess.STARTF_USESHOWWINDOW
             startupinfo.wShowWindow = _subprocess.SW_HIDE
-            comspec = os.environ.get("COMSPEC", unicode("cmd.exe"))
-            args = unicode('{} /c "{}"').format(comspec, args)
+            comspec = os.environ.get("COMSPEC", unicode("cmd.exe"))  # noqa F821
+            args = unicode('{} /c "{}"').format(comspec, args)  # noqa F821
             if (_subprocess.GetVersion() >= 0x80000000 or
                     os.path.basename(comspec).lower() == "command.com"):
                 w9xpopen = self._find_w9xpopen()
-                args = unicode('"%s" %s') % (w9xpopen, args)
+                args = unicode('"%s" %s') % (w9xpopen, args)  # noqa F821
                 creationflags |= _subprocess.CREATE_NEW_CONSOLE
 
         super(Popen, self)._execute_child(

--- a/tox.ini
+++ b/tox.ini
@@ -29,13 +29,6 @@ commands=
     {envpython} -m mkdocs build --clean --verbose --strict
 
 [flake8]
-exclude=rummage/lib/gui/gui.py,site/*,tests/encodings/*,build/*
+exclude=rummage/lib/gui/gui.py,site/*,tests/encodings/*,build/*,*/portalocker.py,.tox/*
 max-line-length=120
-ignore=D202,D203,D401
-putty-ignore=
-    rummage/lib/gui/*.py : +N802
-    tests/*.py : +N802
-    rummage/lib/util/win_subprocess.py : +E241,E266,N801,N802
-    rummage/lib/gui/controls/autocomplete_combo.py : +N803
-    rummage/lib/gui/settings/portalocker.py : +D412
-    rummage/lib/util/__init__.py : +N806
+ignore=D202,D203,D401,N802,N801,N803,N806


### PR DESCRIPTION
Ditch flake8-putty which is locked to <2.  It is mainly used to ignore naming issues with wxpython, but I don't have an issue with accidentally messing up naming conventions, and I can easily catch those kinds of issues in pull requests via a review.  Other issues were fixes that we ignored due to lazyness. Also, now we will run flake8 on Python3 instead of 2.  I want to prepare for when PY2 is no longer supported in 2020 as we will most likely drop PY2 support then ourselves.