### PR TITLE
Auto encoding gen

### DIFF
--- a/gui.fbp
+++ b/gui.fbp
@@ -2658,7 +2658,7 @@
                                                                                                         <property name="selection">0</property>
                                                                                                         <property name="show">1</property>
                                                                                                         <property name="size"></property>
-                                                                                                        <property name="style">wxCB_SORT</property>
+                                                                                                        <property name="style"></property>
                                                                                                         <property name="subclass"></property>
                                                                                                         <property name="toolbar_pane">0</property>
                                                                                                         <property name="tooltip"></property>

--- a/rummage/lib/gui/gui.py
+++ b/rummage/lib/gui/gui.py
@@ -170,7 +170,7 @@ class RummageFrame ( wx.Frame ):
 		fgSizer40.Add( self.m_force_encode_checkbox, 0, wx.ALL, 5 )
 		
 		m_force_encode_choiceChoices = []
-		self.m_force_encode_choice = wx.Choice( self.m_settings_panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, m_force_encode_choiceChoices, wx.CB_SORT )
+		self.m_force_encode_choice = wx.Choice( self.m_settings_panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, m_force_encode_choiceChoices, 0 )
 		self.m_force_encode_choice.SetSelection( 0 )
 		fgSizer40.Add( self.m_force_encode_choice, 0, wx.ALL|wx.EXPAND, 5 )
 		

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -728,10 +728,7 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         encode_val = util.normalize_encoding_name(Settings.get_search_setting("force_encode", "ASCII"))
         if encode_val is None:
             encode_val == "ASCII"
-        try:
-            index = ENCODINGS.index(encode_val)
-        except ValueError:
-            index == wx.NOT_FOUND
+        index = self.m_force_encode_choice.FindString(encode_val)
         if index != wx.NOT_FOUND:
             self.m_force_encode_choice.SetSelection(index)
         self.m_bestmatch_checkbox.SetValue(Settings.get_search_setting("bestmatch_toggle", False))

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -728,7 +728,10 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         encode_val = util.normalize_encoding_name(Settings.get_search_setting("force_encode", "ASCII"))
         if encode_val is None:
             encode_val == "ASCII"
-        index = self.m_force_encode_choice.FindString(encode_val)
+        try:
+            index = ENCODINGS.index(encode_val)
+        except ValueError:
+            index == wx.NOT_FOUND
         if index != wx.NOT_FOUND:
             self.m_force_encode_choice.SetSelection(index)
         self.m_bestmatch_checkbox.SetValue(Settings.get_search_setting("bestmatch_toggle", False))

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -78,98 +78,7 @@ LIMIT_COMPARE = {
     3: "lt"
 }
 
-ENCODINGS = [
-    "ASCII",
-    "BIG5",
-    "BIG5-HKSCS",
-    "BIN",
-    "CP037",
-    "CP154",
-    "CP424",
-    "CP437",
-    "CP500",
-    "CP720",
-    "CP737",
-    "CP775",
-    "CP850",
-    "CP852",
-    "CP855",
-    "CP856",
-    "CP857",
-    "CP858",
-    "CP860",
-    "CP861",
-    "CP862",
-    "CP863",
-    "CP864",
-    "CP865",
-    "CP866",
-    "CP869",
-    "CP874",
-    "CP875",
-    "CP949",
-    "CP950",
-    "CP1006",
-    "CP1026",
-    "CP1140",
-    "EUC-JP",
-    "EUC-JIS-2004",
-    "EUC-JISX0213",
-    "EUC-KR",
-    "GB2312",
-    "GBK",
-    "GB18030",
-    "HZ",
-    "ISO-2022-JP",
-    "ISO-2022-JP-1",
-    "ISO-2022-JP-2",
-    "ISO-2022-JP-2004",
-    "ISO-2022-JP-3",
-    "ISO-2022-JP-ext",
-    "ISO-2022-KR",
-    "ISO-8859-2",
-    "ISO-8859-3",
-    "ISO-8859-4",
-    "ISO-8859-5",
-    "ISO-8859-6",
-    "ISO-8859-7",
-    "ISO-8859-8",
-    "ISO-8859-9",
-    "ISO-8859-10",
-    "ISO-8859-13",
-    "ISO-8859-14",
-    "ISO-8859-15",
-    "ISO-8859-16",
-    "JOHAB",
-    "KOI8-R",
-    "KOI8-U",
-    "LATIN-1",
-    "MAC-CYRILLIC",
-    "MAC-GREEK",
-    "MAC-ICELAND",
-    "MAC-LATIN2",
-    "MAC-ROMAN",
-    "MAC-TURKISH",
-    "MS-KANJI",
-    "SHIFT-JIS",
-    "SHIFT-JIS-2004",
-    "SHIFT-JISX0213",
-    "UTF-32-BE",
-    "UTF-32-LE",
-    "UTF-16-BE",
-    "UTF-16-LE",
-    "UTF-7",
-    "UTF-8",
-    "WINDOWS-1250",
-    "WINDOWS-1251",
-    "WINDOWS-1252",
-    "WINDOWS-1253",
-    "WINDOWS-1254",
-    "WINDOWS-1255",
-    "WINDOWS-1256",
-    "WINDOWS-1257",
-    "WINDOWS-1258"
-]
+ENCODINGS = util.get_encodings()
 
 
 def eng_to_i18n(string, mapping):
@@ -816,7 +725,9 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         self.m_count_only_checkbox.SetValue(Settings.get_search_setting("count_only_toggle", False))
         self.m_backup_checkbox.SetValue(Settings.get_search_setting("backup_toggle", True))
         self.m_force_encode_checkbox.SetValue(Settings.get_search_setting("force_encode_toggle", False))
-        encode_val = Settings.get_search_setting("force_encode", "ASCII")
+        encode_val = util.normalize_encoding_name(Settings.get_search_setting("force_encode", "ASCII"))
+        if encode_val is None:
+            encode_val == "ASCII"
         index = self.m_force_encode_choice.FindString(encode_val)
         if index != wx.NOT_FOUND:
             self.m_force_encode_choice.SetSelection(index)

--- a/rummage/lib/util/__init__.py
+++ b/rummage/lib/util/__init__.py
@@ -9,6 +9,7 @@ import copy
 import struct
 import codecs
 import json
+from encodings.aliases import aliases
 from .file_strip.json import sanitize_json
 
 MAXUNICODE = sys.maxunicode
@@ -172,6 +173,33 @@ def write_json(filename, obj):
         fail = True
 
     return fail
+
+
+def normalize_encoding_name(original_name):
+    """Normalize the encoding names."""
+
+    name = None
+    try:
+        name = codecs.lookup(original_name).name.upper().replace('_', '-')
+    except LookupError as e:
+        if original_name.upper() == 'BIN':
+            name = 'BIN'
+    return name
+
+
+def get_encodings():
+    """Get list of all encodings."""
+
+    exclude = ('BASE64', 'BZ2', 'HEX', 'QUOPRI', 'ROT-13', 'UU', 'ZLIB')
+    elist = set()
+    elist.add('BIN')
+    for k in aliases.keys():
+        value = normalize_encoding_name(k)
+        if value is not None and value not in exclude:
+            elist.add(value)
+    elist = list(elist)
+    elist.sort()
+    return elist
 
 
 def to_unicode_argv():

--- a/rummage/lib/util/__init__.py
+++ b/rummage/lib/util/__init__.py
@@ -9,6 +9,7 @@ import copy
 import struct
 import codecs
 import json
+from itertools import groupby
 from encodings.aliases import aliases
 from .file_strip.json import sanitize_json
 
@@ -175,6 +176,20 @@ def write_json(filename, obj):
     return fail
 
 
+def numeric_sort(text):
+    """Sort numbers in strings as actual numbers."""
+
+    final_text = []
+    for digit, g in groupby(text, lambda x: x.isdigit()):
+        val = "".join(g)
+        if digit:
+            final_text.append(int(val))
+        else:
+            final_text.append(val)
+
+    return final_text
+
+
 def normalize_encoding_name(original_name):
     """Normalize the encoding names."""
 
@@ -198,7 +213,7 @@ def get_encodings():
         if value is not None and value not in exclude:
             elist.add(value)
     elist = list(elist)
-    elist.sort()
+    elist = sorted(elist, key=numeric_sort)
     return elist
 
 


### PR DESCRIPTION
Generate the encoding list on startup for the given Python.  Sort them (treating numbers as actual numbers during sort) and add them to the choice control.