### PR TITLE
New features etc. for 3.4.0

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -40,6 +40,7 @@ macOS
 multi
 plugin
 plugins
+pre
 regex
 reinstalling
 requesters

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 
+- **NEW**: Require latest backrefs 3.0.1.
 - **NEW**: Add extension column in results.
 - **NEW**: Status now just shows `[ACTIVE]` or `[DONE]` instead of a misleading percentage.
 - **NEW**: Can now multi-select and mass open files in your editor.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.0
+
+- **NEW**: Add extension column in results.
+- **FIX**: Result item hover not showing file name in status bar.
+
 ## 3.3.0
 
 - **NEW**: Add changelog link in menu for quick reference.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -4,7 +4,11 @@
 
 - **NEW**: Add extension column in results.
 - **NEW**: Status now just shows `[ACTIVE]` or `[DONE]` instead of a misleading percentage.
+- **NEW**: Can now multi-select and mass open files in your editor.
+- **NEW**: Better error feedback in regex tester.
+- **NEW**: Remove current directory from Python path when opening Rummage to prevent it from importing local libraries when launched inside a Python project.  This mainly affects `python -m rummage` and `pythonw -m rummage` launching.
 - **FIX**: Result item hover not showing file name in status bar.
+- **FIX**: Warnings in plugin system.
 
 ## 3.3.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -2,7 +2,7 @@
 
 ## 3.4.0
 
-- **NEW**: Require latest backrefs 3.0.1.
+- **NEW**: Require latest Backrefs 3.0.1.
 - **NEW**: Add extension column in results.
 - **NEW**: Status now just shows `[ACTIVE]` or `[DONE]` instead of a misleading percentage.
 - **NEW**: Can now multi-select and mass open files in your editor.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -3,6 +3,7 @@
 ## 3.4.0
 
 - **NEW**: Add extension column in results.
+- **NEW**: Status now just shows `[ACTIVE]` or `[DONE]` instead of a misleading percentage.
 - **FIX**: Result item hover not showing file name in status bar.
 
 ## 3.3.0

--- a/docs/src/markdown/installation.md
+++ b/docs/src/markdown/installation.md
@@ -12,32 +12,41 @@ Name                             | Details
 [`wxPython`\ 4.0.0a3+][wxpython] | The new wxPython 4.0.0 is required for for Rummage to run in Python 2 and Python 3. Classic wxPython support has unfortunately be dropped.
 [`regex`\ 2015.07.19+][regex]    | **regex** is usage is completely optional, but it is included for those who wish to use it. Regex is a great regular expression engine that adds some nice features such as fuzzy searching, nested char sets, better Unicode support, and more.
 
-!!! warning "Linux Prerequisites"
-    In traditional Linux fashion, there is a little extra work that needs to be done prior to installing.  Linux requires some prerequisites so that it can build wxPython during installation.
+## Linux Prerequisites
 
-    Example is for Ubuntu:
+Prerequisites are related to wxPython, the graphical interface for Rummage. For Windows and macOS, there are no prerequisites as wxPython provides pre-built wheels for these operating systems, so Rummage can be installed directly and quickly with `pip`. Only Linux requires additional work before installing, but check out the wxPython documentation to learn how to build manually if you have reasons to do so.  The rest of this section refers exclusively to Linux, and mainly from an Ubuntu perspective as that is usually the distro I test on.
 
-    ```bash
-    sudo apt-get install dpkg-dev build-essential python2.7-dev libwebkitgtk-dev libjpeg-dev libtiff-dev libgtk2.0-dev libsdl1.2-dev libgstreamer-plugins-base0.10-dev libnotify-dev freeglut3 freeglut3-dev
-    ```
+!!! info "Read First!"
 
-    Replace `python2.7-dev` with the Python version you are using.
+    WxPython is a separate project from Rummage, so this documentation may not always be up to date when it comes to the prerequisites for wxPython.
 
-    For Fedora 26, you need few dependencies to built wxPython:
+    Please check the wxPython prerequisites before installing. Particularly under [this section](https://github.com/wxWidgets/Phoenix/blob/master/README.rst#prerequisites), you should find information about Linux Prerequisites.
 
-    ```bash
-    sudo dnf install gcc-c++ wxGTK-devel gstreamer-devel webkitgtk-devel GConf2-devel gstreamer-plugins-base-devel
-    ```
+    I usually try to keep Ubuntu info up to date, but if you find it is outdated, please let me know.  I rely on the community for other distros.
 
-    If your Linux distribution has `gstreamer` 1.0 available (like the Fedora distro), you can install the dev packages for that instead of the 0.10 version.
+Here are some last known prerequisite for a couple of distros. **Remember, they might be out of date**.
 
-    Be patient while installing Rummage as Linux must build wxPython while macOS and Windows do not.
+Example is for Ubuntu:
 
-    Check out the wxPython document to see if prerequisites have changed: https://github.com/wxWidgets/Phoenix/blob/master/README.rst#prerequisites.
+```bash
+sudo apt-get install python3.5-dev dpkg-dev build-essential libwebkitgtk-dev libjpeg-dev libtiff-dev libgtk2.0-dev libsdl1.2-dev libgstreamer-plugins-base0.10-dev libnotify-dev freeglut3 freeglut3-dev libgtk-3-dev libwebkitgtk-3.0-dev
+```
+
+Replace `python3.5-dev` with the Python version you are using.
+
+For Fedora 26, it has been reported that you need fewer dependencies to build wxPython; I have not personally confirmed this.
+
+```bash
+sudo dnf install gcc-c++ wxGTK-devel gstreamer-devel webkitgtk-devel GConf2-devel gstreamer-plugins-base-devel
+```
+
+If your Linux distribution has `gstreamer` 1.0 available (like the Fedora distro), you can install the dev packages for that instead of the 0.10 version.
+
+After getting all the correct prerequisites, you should be able to install Rummage with `pip`. Be patient while installing Rummage. Linux must build wxPython while macOS and Windows do not. If installing with `pip`, you may be waiting a long time with no real indication of how far along the process is.  If `pip` doesn't work, you can look into building and installing manually.  If you find any of this information, please feel free to offer a pull request or create an issue on GitHub to at least report the problem.
 
 ## Installation
 
-Here are a couple of ways to install and upgrade. Keep in mind if you are a Linux user, you have some prerequisites to install before proceeding: see [Requirements](#requirements).
+Here are a couple of ways to install and upgrade. Keep in mind if you are a Linux user, you have some [prerequisites](#linux-prerequisites) to install before proceeding.
 
 1. Install:
 
@@ -57,8 +66,12 @@ Here are a couple of ways to install and upgrade. Keep in mind if you are a Linu
     rummage
     ```
 
-    !!! warning
-        It is recommended to run the console script `rummage` and not `python -m rummage` as using using `python -m` will look for modules in your current working directory first and may load unexpected things.  Though this is find if you are running it in a folder without Python modules.
+    This is the safest, recommended way to run rummage and will prevent it from loading any Python libraries from your current working directory.
+
+    In some environments it may make sense to run rummage with `python -m rummage` or `pythonw -m rummage` (`pythonw` being the preferred for a GUI script like this).  In some environments, it may be required (see ["Running in Anaconda (macOS)"](#running-in-anaconda-macos)).
+
+    !!! Note "python(w) -m rummage"
+        In general, Rummage uses relative imports and removes the current local directory from the import path to prevent Python from accidentally overwriting an expected module with a local one. In general, it should be safe to use `python -m rummage` or `pythonw -m rummage` most anywhere.  The only module that is imported before this change is `sys`, but there isn't really a way to avoid this.  Using global `rummage` command will always be the safest.
 
 4. If developing on Rummage, you can clone the project, and install the requirements with the following command:
 
@@ -66,13 +79,7 @@ Here are a couple of ways to install and upgrade. Keep in mind if you are a Linu
     pip install -r requirements/project.txt`
     ```
 
-    You can then run the command below. This method will allow you to instantly see your changes between iterations without reinstalling which is great for developing.  If you want to do this in a virtual machine, you can as well.  Like the first method, you should then be able to access Rummage from the command line via `rummage` or `rummage --path mydirectory`.
-
-    ```bash
-    pip install --editable .
-    ```
-
-    When developing, you often want to run the local module, not the one installed. You can do this from the project's root folder and running:
+    When developing, you often want to run the local module, not the one installed. You can do this from the project's root folder by running:
 
     ```
     python -m rummage

--- a/docs/src/markdown/installation.md
+++ b/docs/src/markdown/installation.md
@@ -6,7 +6,7 @@ Rummage has a few requirements when installing.  These will all be taken care of
 
 Name                             | Details
 -------------------------------- | -------
-[`backrefs` 2.1.0+][backrefs]    | Used to extend the `re` or `regex` regular expression engine with additional back references.
+[`backrefs` 3.0.1+][backrefs]    | Used to extend the `re` or `regex` regular expression engine with additional back references.
 [`gntp`][gntp]                   | Used to send notifications to Growl via the the Growl Notification Transport Protocol for all platforms (macOS, Windows, and Linux).
 [`chardet`\ 3.0.4+][chardet]     | Used for file encoding guessing when an encoding is not specified.
 [`wxPython`\ 4.0.0a3+][wxpython] | The new wxPython 4.0.0 is required for for Rummage to run in Python 2 and Python 3. Classic wxPython support has unfortunately be dropped.

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -165,6 +165,8 @@ Replace plugins are written in Python and are loaded by first selecting the `Use
 
 Then the main dialog's `Replace with` text box will become the `Replace plugin` text box with an associated file picker.  Here you can point to your replace plugin file.
 
+Replace plugins aren't meant to be full, complex modules that import lots of other relative files.  They are meant to be a single, compact script, but inside that script, you can import anything that is *already* installed in your Python environment.
+
 ![Enable Replace Plugin](/images/plugin_input.png)
 
 #### Writing a Plugin

--- a/gui.fbp
+++ b/gui.fbp
@@ -13311,7 +13311,7 @@
                                                 <property name="flag">wxEXPAND</property>
                                                 <property name="proportion">1</property>
                                                 <object class="wxFlexGridSizer" expanded="0">
-                                                    <property name="cols">3</property>
+                                                    <property name="cols">4</property>
                                                     <property name="flexible_direction">wxHORIZONTAL</property>
                                                     <property name="growablecols">1</property>
                                                     <property name="growablerows"></property>
@@ -13494,6 +13494,16 @@
                                                             <event name="OnTextMaxLen"></event>
                                                             <event name="OnTextURL"></event>
                                                             <event name="OnUpdateUI"></event>
+                                                        </object>
+                                                    </object>
+                                                    <object class="sizeritem" expanded="0">
+                                                        <property name="border">5</property>
+                                                        <property name="flag">wxEXPAND</property>
+                                                        <property name="proportion">1</property>
+                                                        <object class="spacer" expanded="0">
+                                                            <property name="height">0</property>
+                                                            <property name="permission">protected</property>
+                                                            <property name="width">0</property>
                                                         </object>
                                                     </object>
                                                     <object class="sizeritem" expanded="0">
@@ -13743,6 +13753,94 @@
                                                             <property name="window_name"></property>
                                                             <property name="window_style"></property>
                                                             <event name="OnButtonClick"></event>
+                                                            <event name="OnChar"></event>
+                                                            <event name="OnEnterWindow"></event>
+                                                            <event name="OnEraseBackground"></event>
+                                                            <event name="OnKeyDown"></event>
+                                                            <event name="OnKeyUp"></event>
+                                                            <event name="OnKillFocus"></event>
+                                                            <event name="OnLeaveWindow"></event>
+                                                            <event name="OnLeftDClick"></event>
+                                                            <event name="OnLeftDown"></event>
+                                                            <event name="OnLeftUp"></event>
+                                                            <event name="OnMiddleDClick"></event>
+                                                            <event name="OnMiddleDown"></event>
+                                                            <event name="OnMiddleUp"></event>
+                                                            <event name="OnMotion"></event>
+                                                            <event name="OnMouseEvents"></event>
+                                                            <event name="OnMouseWheel"></event>
+                                                            <event name="OnPaint"></event>
+                                                            <event name="OnRightDClick"></event>
+                                                            <event name="OnRightDown"></event>
+                                                            <event name="OnRightUp"></event>
+                                                            <event name="OnSetFocus"></event>
+                                                            <event name="OnSize"></event>
+                                                            <event name="OnUpdateUI"></event>
+                                                        </object>
+                                                    </object>
+                                                    <object class="sizeritem" expanded="0">
+                                                        <property name="border">5</property>
+                                                        <property name="flag">wxALL</property>
+                                                        <property name="proportion">0</property>
+                                                        <object class="wxButton" expanded="0">
+                                                            <property name="BottomDockable">1</property>
+                                                            <property name="LeftDockable">1</property>
+                                                            <property name="RightDockable">1</property>
+                                                            <property name="TopDockable">1</property>
+                                                            <property name="aui_layer"></property>
+                                                            <property name="aui_name"></property>
+                                                            <property name="aui_position"></property>
+                                                            <property name="aui_row"></property>
+                                                            <property name="best_size"></property>
+                                                            <property name="bg"></property>
+                                                            <property name="caption"></property>
+                                                            <property name="caption_visible">1</property>
+                                                            <property name="center_pane">0</property>
+                                                            <property name="close_button">1</property>
+                                                            <property name="context_help"></property>
+                                                            <property name="context_menu">1</property>
+                                                            <property name="default">0</property>
+                                                            <property name="default_pane">0</property>
+                                                            <property name="dock">Dock</property>
+                                                            <property name="dock_fixed">0</property>
+                                                            <property name="docking">Left</property>
+                                                            <property name="enabled">1</property>
+                                                            <property name="fg"></property>
+                                                            <property name="floatable">1</property>
+                                                            <property name="font"></property>
+                                                            <property name="gripper">0</property>
+                                                            <property name="hidden">0</property>
+                                                            <property name="id">wxID_ANY</property>
+                                                            <property name="label">Reload</property>
+                                                            <property name="max_size"></property>
+                                                            <property name="maximize_button">0</property>
+                                                            <property name="maximum_size"></property>
+                                                            <property name="min_size"></property>
+                                                            <property name="minimize_button">0</property>
+                                                            <property name="minimum_size"></property>
+                                                            <property name="moveable">1</property>
+                                                            <property name="name">m_reload_button</property>
+                                                            <property name="pane_border">1</property>
+                                                            <property name="pane_position"></property>
+                                                            <property name="pane_size"></property>
+                                                            <property name="permission">protected</property>
+                                                            <property name="pin_button">1</property>
+                                                            <property name="pos"></property>
+                                                            <property name="resize">Resizable</property>
+                                                            <property name="show">1</property>
+                                                            <property name="size"></property>
+                                                            <property name="style">wxBU_EXACTFIT</property>
+                                                            <property name="subclass"></property>
+                                                            <property name="toolbar_pane">0</property>
+                                                            <property name="tooltip"></property>
+                                                            <property name="validator_data_type"></property>
+                                                            <property name="validator_style">wxFILTER_NONE</property>
+                                                            <property name="validator_type">wxDefaultValidator</property>
+                                                            <property name="validator_variable"></property>
+                                                            <property name="window_extra_style"></property>
+                                                            <property name="window_name"></property>
+                                                            <property name="window_style"></property>
+                                                            <event name="OnButtonClick">on_reload_click</event>
                                                             <event name="OnChar"></event>
                                                             <event name="OnEnterWindow"></event>
                                                             <event name="OnEraseBackground"></event>

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,5 +1,5 @@
 gntp>=1.0.2
 chardet>=3.0.4
-backrefs>=2.1,<3.0
+backrefs>=3.0.1,<4.0
 regex
 wxpython>=4.0.0a3

--- a/requirements/test-project.txt
+++ b/requirements/test-project.txt
@@ -1,4 +1,4 @@
 gntp>=1.0.2
 chardet>=3.0.4
-backrefs>=2.1,<3.0
+backrefs>=3.0.1,<4.0
 regex

--- a/rummage/__main__.py
+++ b/rummage/__main__.py
@@ -20,8 +20,9 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import unicode_literals
 from __future__ import absolute_import
-import argparse
+from .lib import safe_import
 import sys
+import argparse
 import os
 from .lib import util
 from .lib import __meta__

--- a/rummage/__main__.py
+++ b/rummage/__main__.py
@@ -20,7 +20,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from .lib import safe_import
+from .lib import safe_import  # noqa: F401
 import sys
 import argparse
 import os

--- a/rummage/lib/gui/controls/dynamic_lists.py
+++ b/rummage/lib/gui/controls/dynamic_lists.py
@@ -156,6 +156,7 @@ class DynamicList(wx.ListCtrl, listmix.ColumnSorterMixin):
                 self.sort_init = False
             self.resize_last_column()
             self.size_sample = 0
+            self.complete = True
 
     def get_item_text(self, idx, col, absolute=False):
         """Return the text for the given item and col."""

--- a/rummage/lib/gui/controls/result_lists.py
+++ b/rummage/lib/gui/controls/result_lists.py
@@ -227,15 +227,10 @@ class ResultFileList(DynamicList):
     def on_dclick(self, event):
         """Open file at in editor with optional line and column argument."""
 
-        with self.wait:
-            pos = event.GetPosition()
-            item = self.HitTestSubItem(pos)[0]
-            if item != -1:
-                filename = self.GetItem(item, col=0).GetText()
-                path = self.GetItem(item, col=FILE_PATH).GetText()
-                line = str(self.get_map_item(item, col=FILE_LINE))
-                col = str(self.get_map_item(item, col=FILE_COL))
-                fileops.open_editor(os.path.join(os.path.normpath(path), filename), line, col)
+        pos = event.GetPosition()
+        item = self.HitTestSubItem(pos)[0]
+        if item != -1:
+            self.open_editor(event, item)
         event.Skip()
 
     def open_editor(self, event, item):

--- a/rummage/lib/gui/gui.py
+++ b/rummage/lib/gui/gui.py
@@ -1405,7 +1405,7 @@ class RegexTestDialog ( wx.Dialog ):
 		fgSizer41.SetFlexibleDirection( wx.BOTH )
 		fgSizer41.SetNonFlexibleGrowMode( wx.FLEX_GROWMODE_SPECIFIED )
 		
-		fgSizer39 = wx.FlexGridSizer( 0, 3, 0, 0 )
+		fgSizer39 = wx.FlexGridSizer( 0, 4, 0, 0 )
 		fgSizer39.AddGrowableCol( 1 )
 		fgSizer39.SetFlexibleDirection( wx.HORIZONTAL )
 		fgSizer39.SetNonFlexibleGrowMode( wx.FLEX_GROWMODE_SPECIFIED )
@@ -1420,6 +1420,9 @@ class RegexTestDialog ( wx.Dialog ):
 		
 		fgSizer39.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 		
+		
+		fgSizer39.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+		
 		self.m_replace_label = wx.StaticText( self.m_tester_panel, wx.ID_ANY, u"Replace", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_replace_label.Wrap( -1 )
 		fgSizer39.Add( self.m_replace_label, 0, wx.ALL|wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL, 5 )
@@ -1429,6 +1432,9 @@ class RegexTestDialog ( wx.Dialog ):
 		
 		self.m_replace_plugin_dir_picker = wx.Button( self.m_tester_panel, wx.ID_ANY, u"...", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT )
 		fgSizer39.Add( self.m_replace_plugin_dir_picker, 0, wx.ALL, 5 )
+		
+		self.m_reload_button = wx.Button( self.m_tester_panel, wx.ID_ANY, u"Reload", wx.DefaultPosition, wx.DefaultSize, wx.BU_EXACTFIT )
+		fgSizer39.Add( self.m_reload_button, 0, wx.ALL, 5 )
 		
 		
 		fgSizer41.Add( fgSizer39, 1, wx.EXPAND, 5 )
@@ -1558,6 +1564,7 @@ class RegexTestDialog ( wx.Dialog ):
 		self.m_test_text.Bind( wx.EVT_TEXT, self.on_test_changed )
 		self.m_regex_text.Bind( wx.EVT_TEXT, self.on_regex_changed )
 		self.m_replace_text.Bind( wx.EVT_TEXT, self.on_replace_changed )
+		self.m_reload_button.Bind( wx.EVT_BUTTON, self.on_reload_click )
 		self.m_regex_search_checkbox.Bind( wx.EVT_CHECKBOX, self.on_regex_toggle )
 		self.m_case_checkbox.Bind( wx.EVT_CHECKBOX, self.on_case_toggle )
 		self.m_dotmatch_checkbox.Bind( wx.EVT_CHECKBOX, self.on_dot_toggle )
@@ -1588,6 +1595,9 @@ class RegexTestDialog ( wx.Dialog ):
 		event.Skip()
 	
 	def on_replace_changed( self, event ):
+		event.Skip()
+	
+	def on_reload_click( self, event ):
 		event.Skip()
 	
 	def on_regex_toggle( self, event ):

--- a/rummage/lib/gui/regex_test_dialog.py
+++ b/rummage/lib/gui/regex_test_dialog.py
@@ -403,7 +403,7 @@ class RegexTestDialog(gui.RegexTestDialog):
                         time.ctime(),
                         rumcore.text_decode.Encoding('unicode', None)
                     )
-                    replace_test = self.import_plugin(rpattern)(file_info, rum_flags).replace
+                    replace_test = self.import_plugin(rpattern)(file_info, rum_flags)._test
                 elif rpattern:
                     if not is_regex:
                         replace_test = functools.partial(replace_literal, replace=rpattern)

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -1199,7 +1199,8 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         import imp
 
         if script not in self.imported_plugins:
-            module = imp.new_module(script)
+            module = imp.new_module(os.path.splitext(os.path.basename(script))[0])
+            module.__dict__['__file__'] = script
             with open(script, 'rb') as f:
                 encoding = rumcore.text_decode._special_encode_check(f.read(256), '.py')
             with codecs.open(script, 'r', encoding=encoding.encode) as f:

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -1572,10 +1572,11 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         self.m_statusbar.set_status(
             self.UPDATE_STATUS % (
                 (
-                    actually_done, total,
+                    actually_done,
+                    total,
                     skipped,
                     count
-                ) if total != 0 else (0, 0, 0, 0, 0)
+                ) if total != 0 else (0, 0, 0, 0)
             )
         )
         return count

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -466,9 +466,9 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
         self.ERR_IMPORT = _("There was an error attempting to read the settings file!")
 
         # Status
-        self.INIT_STATUS = _("Searching: 0/0 0% Skipped: 0 Matches: 0")
-        self.UPDATE_STATUS = _("Searching: %d/%d %d%% Skipped: %d Matches: %d")
-        self.FINAL_STATUS = _("Searching: %d/%d %d%% Skipped: %d Matches: %d Benchmark: %s")
+        self.INIT_STATUS = _("Searching: 0/0 [ACTIVE] Skipped: 0 Matches: 0")
+        self.UPDATE_STATUS = _("Searching: %d/%d [ACTIVE] Skipped: %d Matches: %d")
+        self.FINAL_STATUS = _("Searching: %d/%d [DONE] Skipped: %d Matches: %d Benchmark: %s")
 
         # Status bar popup
         self.SB_ERRORS = _("errors")
@@ -1498,7 +1498,6 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
                     self.UPDATE_STATUS % (
                         completed,
                         total,
-                        int(float(completed) / float(total) * 100) if total != 0 else 0,
                         skipped,
                         count
                     )
@@ -1540,7 +1539,6 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
                     self.FINAL_STATUS % (
                         completed,
                         total,
-                        (int(float(completed) / float(total) * 100) if total != 0 else 0 if kill else 100),
                         skipped,
                         count,
                         benchmark
@@ -1575,7 +1573,6 @@ class RummageFrame(gui.RummageFrame, DebugFrameExtender):
             self.UPDATE_STATUS % (
                 (
                     actually_done, total,
-                    int(float(actually_done) / float(total) * 100),
                     skipped,
                     count
                 ) if total != 0 else (0, 0, 0, 0, 0)

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -316,7 +316,7 @@ class FileAttrRecord(namedtuple('FileAttrRecord', ['name', 'size', 'modified', '
     """File Attributes."""
 
 
-class FileInfoRecord(namedtuple('FileInfoRecord', ['id', 'name', 'size', 'modified', 'created', 'encoding'])):
+class FileInfoRecord(namedtuple('FileInfoRecord', ['id', 'name', 'size', 'modified', 'created', 'encoding', 'ext'])):
     """A record for tracking file info."""
 
 
@@ -869,7 +869,8 @@ class _FileSearch(object):
             file_obj.size,
             file_obj.modified,
             file_obj.created,
-            self.current_encoding.encode.upper()
+            self.current_encoding.encode.upper(),
+            os.path.splitext(file_obj.name)[1].lower().lstrip('.')
         )
 
         return file_info, error
@@ -1120,6 +1121,7 @@ class _FileSearch(object):
                 FileInfoRecord(
                     self.idx,
                     self.file_obj.name,
+                    None,
                     None,
                     None,
                     None,

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -312,11 +312,11 @@ class RummageException(Exception):
     """Rummage exception."""
 
 
-class FileAttrRecord(namedtuple('FileAttrRecord', ['name', 'size', 'modified', 'created', 'skipped', 'error'])):
+class FileAttrRecord(namedtuple('FileAttrRecord', ['name', 'ext', 'size', 'modified', 'created', 'skipped', 'error'])):
     """File Attributes."""
 
 
-class FileInfoRecord(namedtuple('FileInfoRecord', ['id', 'name', 'size', 'modified', 'created', 'encoding', 'ext'])):
+class FileInfoRecord(namedtuple('FileInfoRecord', ['id', 'name', 'ext', 'size', 'modified', 'created', 'encoding'])):
     """A record for tracking file info."""
 
 
@@ -866,11 +866,11 @@ class _FileSearch(object):
         file_info = FileInfoRecord(
             self.idx,
             file_obj.name,
+            os.path.splitext(file_obj.name)[1].lower().lstrip('.'),
             file_obj.size,
             file_obj.modified,
             file_obj.created,
-            self.current_encoding.encode.upper(),
-            os.path.splitext(file_obj.name)[1].lower().lstrip('.')
+            self.current_encoding.encode.upper()
         )
 
         return file_info, error
@@ -1342,6 +1342,7 @@ class _DirWalker(object):
                         None,
                         None,
                         None,
+                        None,
                         False,
                         get_exception()
                     )
@@ -1361,13 +1362,16 @@ class _DirWalker(object):
                             None,
                             None,
                             None,
+                            None,
                             False,
                             get_exception()
                         )
 
                     if valid:
+                        filename = os.path.join(base, name)
                         yield FileAttrRecord(
-                            os.path.join(base, name),
+                            filename,
+                            os.path.splitext(filename)[1].lower().lstrip('.'),
                             self.current_size,
                             self.modified_time,
                             self.created_time,
@@ -1375,7 +1379,7 @@ class _DirWalker(object):
                             None
                         )
                     else:
-                        yield FileAttrRecord(os.path.join(base, name), None, None, None, True, None)
+                        yield FileAttrRecord(os.path.join(base, name), None, None, None, None, True, None)
 
                     if self.abort:
                         break
@@ -1458,6 +1462,7 @@ class Rummage(object):
                 self.files.append(
                     FileAttrRecord(
                         self.target,
+                        os.path.splitext(self.target).lower().lstrip('.'),
                         os.path.getsize(self.target),
                         getmtime(self.target),
                         getctime(self.target),
@@ -1471,12 +1476,14 @@ class Rummage(object):
                     None,
                     None,
                     None,
+                    None,
                     False,
                     get_exception()
                 )
         elif self.buffer_input:
             self.files.append(
                 FileAttrRecord(
+                    None,
                     None,
                     len(self.target),
                     ctime(),

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -312,6 +312,10 @@ class RummageException(Exception):
     """Rummage exception."""
 
 
+class RummageTestException(Exception):
+    """Rummage exception."""
+
+
 class FileAttrRecord(namedtuple('FileAttrRecord', ['name', 'ext', 'size', 'modified', 'created', 'skipped', 'error'])):
     """File Attributes."""
 
@@ -386,6 +390,20 @@ class ReplacePlugin(object):
         self.file_info = file_info
         self.flags = flags
         self.on_init()
+
+    def _test(self, m):  # pragma: no cover
+        """
+        Used for testing and capturing the exception.
+
+        Needs to raise the RummageTestException.
+        This should not be touched by the user.
+        """
+
+        try:
+            return self.replace(m)
+        except Exception:
+            import traceback
+            raise RummageTestException(util.ustr(traceback.format_exc()))
 
     def on_init(self):
         """Override this function to add initialization setup."""

--- a/rummage/lib/safe_import.py
+++ b/rummage/lib/safe_import.py
@@ -1,0 +1,5 @@
+import sys
+# Prevent us from loading local packages
+# Comment this out if you want rummage to load a local package
+# for testing.
+sys.path.remove('')

--- a/rummage/lib/safe_import.py
+++ b/rummage/lib/safe_import.py
@@ -1,3 +1,4 @@
+"""Safely import other modules without overriding with locals."""
 import sys
 # Prevent us from loading local packages
 # Comment this out if you want rummage to load a local package

--- a/rummage/lib/util/__init__.py
+++ b/rummage/lib/util/__init__.py
@@ -196,7 +196,7 @@ def normalize_encoding_name(original_name):
     name = None
     try:
         name = codecs.lookup(original_name).name.upper().replace('_', '-')
-    except LookupError as e:
+    except LookupError:
         if original_name.upper() == 'BIN':
             name = 'BIN'
     return name

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     install_requires=[
         "gntp>=1.0.2",
         "chardet>=3.0.4",
-        "backrefs>=2.1,<3.0",
+        "backrefs>=3.0.1,<4.0",
         "regex",
         "wxpython>=4.0.0a3"
     ],

--- a/tests/test_rumcore.py
+++ b/tests/test_rumcore.py
@@ -816,6 +816,7 @@ class TestFileSearch(unittest.TestCase):
 
         return rc.FileAttrRecord(
             name,
+            os.path.splitext(name)[1].lower().lstrip('.'),
             os.path.getsize(name),
             rc.getmtime(name),
             rc.getctime(name),


### PR DESCRIPTION
- **NEW**: Add extension column in results.
- **NEW**: Status now just shows `[ACTIVE]` or `[DONE]` instead of a misleading percentage.
- **NEW**: Can now multi-select and mass open files in your editor.
- **NEW**: Better error feedback in regex tester.
- **NEW**: Remove current directory from Python path when opening Rummage to prevent it from importing local libraries when launched inside a Python project.  This mainly affects `python -m rummage` and `pythonw -m rummage` launching.
- **FIX**: Result item hover not showing file name in status bar.
- **FIX**: Warnings in plugin system.