### PR TITLE
Fix reverse search, fix bregex import error

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.4.3
+
+Jan 23, 2018
+
+- **FIX**: Import of `bregex` when `regex` is not installed.
+- **FIX**: Backwards search did not reassemble text proper.
+
 ## 3.4.2
 
 Jan 23, 2018

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -29,7 +29,7 @@ import os
 import re
 import codecs
 import wx.lib.newevent
-from backrefs import bre, bregex
+from backrefs import bre
 from .settings import Settings
 from .actions import export_html
 from .actions import export_csv
@@ -59,6 +59,10 @@ from .. import __meta__
 from .. import rumcore
 from .. import util
 import decimal
+if rumcore.REGEX_SUPPORT:
+    from backrefs import bregex
+else:
+    bregex = None
 
 PostResizeEvent, EVT_POST_RESIZE = wx.lib.newevent.NewEvent()
 

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -526,6 +526,7 @@ class _FileSearch(object):
         self.count_only = bool(self.flags & COUNT_ONLY)
         self.truncate_lines = bool(self.flags & TRUNCATE_LINES)
         self.process_binary = bool(self.flags & PROCESS_BINARY)
+        self.reverse = False
         self.backup = bool(self.flags & BACKUP)
         self.backup2folder = bool(self.flags & BACKUP_FOLDER)
         self.backup_ext = ('.%s' % backup_location) if not self.backup2folder else DEFAULT_BAK
@@ -802,6 +803,13 @@ class _FileSearch(object):
                         template = sre_parse.parse_template(replace, pattern)
                         self.expand = lambda m, t=template: sre_parse.expand_template(t, m)
 
+            if REGEX_SUPPORT and isinstance(pattern, bregex._REGEX_TYPE):
+                self.reverse = bool(pattern.flags & regex.REVERSE)
+            else:
+                self.reverse = False
+
+            self.text_offset = len(file_content) if self.reverse else 0
+
             for m in pattern.finditer(file_content):
                 yield m
 
@@ -933,13 +941,22 @@ class _FileSearch(object):
                         file_info = file_info._replace(encoding=self.current_encoding.encode.upper())
 
                     if not skip:
-                        offset = 0
 
                         pattern, replace, flags = self.search_obj[0]
+                        if REGEX_SUPPORT and isinstance(pattern, bregex._REGEX_TYPE):
+                            self.reverse = bool(pattern.flags & regex.REVERSE)
+                        else:
+                            self.reverse = False
+
                         for m in self._findall(rum_buff, pattern, replace, flags, file_info):
-                            text.append(rum_buff[offset:m.start(0)])
-                            text.append(self.expand_match(m))
-                            offset = m.end(0)
+                            if self.reverse:
+                                text.appendleft(rum_buff[m.end(0):self.text_offset])
+                                text.appendleft(self.expand_match(m))
+                                self.text_offset = m.start(0)
+                            else:
+                                text.append(rum_buff[self.text_offset:m.start(0)])
+                                text.append(self.expand_match(m))
+                                self.text_offset = m.end(0)
 
                             yield FileRecord(
                                 file_info,
@@ -961,21 +978,29 @@ class _FileSearch(object):
 
                         # Grab the rest of the file if we found things to replace.
                         if not self.abort and (text or len(self.search_obj) > 1):
-                            text.append(rum_buff[offset:])
+                            if self.reverse:
+                                text.appendleft(rum_buff[:self.text_offset])
+                            else:
+                                text.append(rum_buff[self.text_offset:])
 
                 # Additional chained replaces
                 count = 1
-                if not self.abort and len(self.search_obj) > 1:
+                if not skip and not self.abort and len(self.search_obj) > 1:
 
                     for pattern, replace, flags in self.search_obj[1:]:
+
                         text2 = (b'' if self.is_binary else '').join(text)
                         text = deque()
-                        offset = 0
 
                         for m in self._findall(text2, pattern, replace, flags, file_info):
-                            text.append(text2[offset:m.start(0)])
-                            text.append(self.expand_match(m))
-                            offset = m.end(0)
+                            if self.reverse:
+                                text.appendleft(text2[m.end(0):self.text_offset])
+                                text.appendleft(self.expand_match(m))
+                                self.text_offset = m.start(0)
+                            else:
+                                text.append(text2[self.text_offset:m.start(0)])
+                                text.append(self.expand_match(m))
+                                self.text_offset = m.end(0)
 
                             yield FileRecord(
                                 file_info,
@@ -999,7 +1024,10 @@ class _FileSearch(object):
 
                         # Grab the rest of the file if we found things to replace.
                         if not self.abort and (text or count < len(self.search_obj)):
-                            text.append(text2[offset:])
+                            if self.reverse:
+                                text.appendleft(text2[:self.text_offset])
+                            else:
+                                text.append(text2[self.text_offset:])
 
                         if self.abort:
                             break
@@ -1482,7 +1510,7 @@ class Rummage(object):
                 self.files.append(
                     FileAttrRecord(
                         self.target,
-                        os.path.splitext(self.target).lower().lstrip('.'),
+                        os.path.splitext(self.target)[1].lower().lstrip('.'),
                         os.path.getsize(self.target),
                         getmtime(self.target),
                         getctime(self.target),


### PR DESCRIPTION
Turns out testing sub was nowhere near sufficient  to understand reverse.  regex.REVERSE literally returns all the matches in reverse order, especially when it is iteratting. Fix behavior in core and in test dialog.

Finally tested without regex installed.  This should be squashed for sure this time.