### PR TITLE
Rework wildcard patterns

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -31,6 +31,7 @@ Rummage's
 Sep
 Tox
 UI
+Wildcard
 Xcode
 cChardet
 changelog
@@ -46,6 +47,7 @@ dotfiles
 dropdown
 emoji
 endian
+fnmatch
 grepWin
 inline
 macOS
@@ -69,4 +71,5 @@ taskbar
 timestamp
 tuple
 wiki
+wildcard
 wxPython

--- a/docs/src/markdown/_snippets/links.md
+++ b/docs/src/markdown/_snippets/links.md
@@ -7,6 +7,7 @@
 [cchardet]: https://pypi.python.org/pypi/cchardet
 [chardet]: https://pypi.python.org/pypi/chardet
 [filelock]: https://pypi.python.org/pypi/filelock/
+[fnmatch]: https://docs.python.org/3.6/library/fnmatch.html
 [format-string]: https://docs.python.org/2/library/string.html#format-string-syntax
 [gntp]: https://github.com/kdfm/gntp
 [grepwin]: http://stefanstools.sourceforge.net/grepWin.html

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -10,6 +10,9 @@
 - **NEW**: Add copy button to support info dialog and ensure support info is read only.
 - **NEW**: Don't copy notification icons to user folder for use, but use the packaged icons directly from library.
 - **NEW**: Provide better support for localization.  Build current language translation on install and bundle in library directly.
+- **FIX**: Wildcard pattern splitting on `|` inside a sequence.
+- **FIX**: Wildcard patterns not allowing character tokens such as `\x70`, `\u0070`, `\N{unicode name}`, `\160`, and standard escapes like `\t` etc.
+- **FIX**: Incorrect documentation on wildcard patterns.
 
 ## 3.5.0
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -301,7 +301,7 @@ Include\ binary\ files | Forces Rummage to search binary files.
 
 ### File Patterns
 
-If you don't select the `Regex` checkbox to the right of `Exclude folders` or `Files which match`, those patterns will be simple wildcard patterns instead of regular expressions. The wildcard syntax mimics Python's [fnmatch module][fnmatch], but with two additions.
+If you don't select the `Regex` check box to the right of `Exclude folders` or `Files which match`, those patterns will be simple wildcard patterns instead of regular expressions. The wildcard syntax mimics Python's [fnmatch module][fnmatch], but with two additions.
 
 Pattern  | Meaning
 -------- | -------

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -284,19 +284,52 @@ LITERAL = 0x10000           # Literal search
 
 The limit search pattern contains inputs and toggles to filter which files will be searched.  Some people may like to set up the filters and hide the panel.  If this is desired, you can select in the window's menu **View-->Hide Limit Search Panel**, and the panel will be hidden.
 
+!!! tip "Tip"
+    If you don't specify a search pattern, Rummage will use your file filter and just show files that match your file filter pattern.
+
 Limiter                | Description
 ---------------------- |------------
 Size\ of               | Limits files that are searched by size in Kilobytes.  Files are limited by whether they are greater than, less than, or equal to the specified size.  Setting the dropdown to `any` disables the filter and allows any file size to be searched. It is recommended to cap search sizes in projects with very large files for the best performances.  The more complex the search pattern, the longer it will take to search a really large file.
 Modified               | Limits the files to be searched by the modified timestamp.  It contains a date picker and time picker that are used to specify the target date and time. Files are limited by whether their timestamp comes before, after, or on specified date time.  Setting the dropdown to `on any` will disable the filter and allow a file with any timestamp to be searched.
 Created                | Limits the files to be searched by the creation timestamp.  It contains a date picker and time picker that are used to specify the target date and time. Files are limited by whether their timestamp comes before, after, or on specified date time.  Setting the dropdown to `on any` will disable the filter and allow a file with any timestamp to be searched.
-Files\ which\ match    | Specifies a file pattern for files that should be searched.  Multiple file patterns can be specified with `;` used as a separator. If the Regex toggle to the text box's right is selected, the file pattern must be a regular expression pattern.  You can select previously used patterns by expanding the dropdown panel for the input.
-Exclude\ folders       | Specifies a directory exclude pattern to filter out folders that are not to be crawled.  Multiple file patterns can be specified with `;` used as a separator.  If the Regex toggle to the text box's right is selected, the file pattern must be a regular expression pattern.  You can select previously used patterns by expanding the dropdown panel for the input.
+Files\ which\ match    | Specifies a file pattern for files that should be searched.  Multiple file patterns can be specified with `|` used as a separator. If the Regex toggle to the text box's right is selected, the file pattern must be a regular expression pattern.  You can select previously used patterns by expanding the dropdown panel for the input.
+Exclude\ folders       | Specifies a directory exclude pattern to filter out folders that are not to be crawled.  Multiple file patterns can be specified with `|` used as a separator.  If the Regex toggle to the text box's right is selected, the file pattern must be a regular expression pattern.  You can select previously used patterns by expanding the dropdown panel for the input.
 Include\ subfolders    | Indicates that folders should be recursively searched.
 Include\ hidden        | The given OS's native hidden files, folders and dotfiles will be included in the search.
 Include\ binary\ files | Forces Rummage to search binary files.
 
-!!! tip "Tip"
-    If you don't specify a search pattern, Rummage will use your file filter and just show files that match your file filter pattern.
+
+### File Patterns
+
+If you don't select the `Regex` checkbox to the right of `Exclude folders` or `Files which match`, those patterns will be simple wildcard patterns instead of regular expressions. The wildcard syntax mimics Python's [fnmatch module][fnmatch], but with two additions.
+
+Pattern  | Meaning
+-------- | -------
+`*`      | Matches everything.
+`?`      | Matches any single character.
+`[seq]`  | Matches any character in seq.
+`[!seq]` | Matches any character not in seq.
+`|`      | Separates multiple patterns.
+`-`      | If used at the start of a pattern, the meaning is changed to exclude (or include in the case of `Exclude folders`).
+
+You can also use Python notation for specifying characters to make things like Unicode character input easier. So you can use `\x70`, `\u0070`, `\160`, for bytes, Unicode, or octal style character notation. You can also use Unicode names: `\N{unicode name}`.
+
+!!! example "Example Patterns"
+
+    This would match all Python files of `.py` extensions excluding `__init__.py`:
+
+    ```
+    *.py|-__init__.py
+    ```
+
+    This would exclude all folders with `name` followed by a single digit number, except `name3` which we will always include.
+
+    ```
+    name[0-9]|-name3
+    ```
+
+    If you need to escape `-` or `|`, you can put them in a sequence: `[-|]`. Remember to place `-` at the beginning of a sequence as `-` is also used to specify character ranges: `[a-z]`.
+
 
 ## Export to CSV or HTML
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -301,7 +301,7 @@ Include\ binary\ files | Forces Rummage to search binary files.
 
 ### File Patterns
 
-If you don't select the `Regex` check box to the right of `Exclude folders` or `Files which match`, those patterns will be simple wildcard patterns instead of regular expressions. The wildcard syntax mimics Python's [fnmatch module][fnmatch], but with two additions.
+When the `Regex` check box is selected to the right of `Exclude folders` or `Files which match`, the currently configured regular expression engine will be used, and the patterns will be configured for case insensitive matching. If you don't select the `Regex`, those patterns will be a simple wildcard pattern instead of a regular expression pattern, and the wildcard matches will also be case insensitive. The wildcard syntax mimics Python's [fnmatch module][fnmatch], but with two additions.
 
 Pattern  | Meaning
 -------- | -------

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -310,19 +310,21 @@ Pattern  | Meaning
 `[seq]`  | Matches any character in seq.
 `[!seq]` | Matches any character not in seq.
 `|`      | Separates multiple patterns.
-`-`      | If used at the start of a pattern, the meaning is changed to exclude (or include in the case of `Exclude folders`).
+`-`      | If used at the start of a pattern, the pattern is treated as an exception to other applied patterns.
 
 You can also use Python notation for specifying characters to make things like Unicode character input easier. So you can use `\x70`, `\u0070`, `\160`, for bytes, Unicode, or octal style character notation. You can also use Unicode names: `\N{unicode name}`.
 
 !!! example "Example Patterns"
 
-    This would match all Python files of `.py` extensions excluding `__init__.py`:
+    Used in the `Files which match` box, this would match all Python files of `.py` extensions excluding `__init__.py`:
 
     ```
     *.py|-__init__.py
     ```
 
-    This would exclude all folders with `name` followed by a single digit number, except `name3` which we will always include.
+    Keep in mind that `-` patterns augment logic of other patterns, you can't just specify `-__init__.py` as it is more an exception to non `-` matches as shown above.
+
+    Used in the `Exclude folders`, this would exclude all folders with `name` followed by a single digit, except `name3` which we will always be included.
 
     ```
     name[0-9]|-name3

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -27,8 +27,9 @@ import os
 import re
 import shutil
 import sre_parse
+import unicodedata
+import backrefs
 from collections import namedtuple
-from fnmatch import fnmatch
 from time import ctime
 from backrefs import bre
 from collections import deque
@@ -92,6 +93,10 @@ TRUNCATE_LENGTH = 120
 
 DEFAULT_BAK = 'rum-bak'
 DEFAULT_FOLDER_BAK = '.rum-bak'
+
+_OCTAL = frozenset(('0', '1', '2', '3', '4', '5', '6', '7'))
+_STANDARD_ESCAPES = frozenset(('a', 'b', 'f', 'n', 'r', 't', 'v'))
+_CHAR_ESCAPES = frozenset(('u', 'U', 'x'))
 
 U32 = (
     'u32', 'utf32', 'utf_32'
@@ -340,6 +345,189 @@ class BufferRecord(namedtuple('BufferRecord', ['content', 'error'])):
 
 class ErrorRecord(namedtuple('ErrorRecord', ['error'])):
     """A record for non-file related errors."""
+
+
+class _StringIter(object):
+    """Preprocess replace tokens."""
+
+    def __init__(self, string):
+        """Initialize."""
+
+        self.string = string
+        self.max_index = len(string) - 1
+        self.index = 0
+
+    def __iter__(self):
+        """Iterate."""
+
+        return self
+
+    def __next__(self):
+        """Python 3 iterator compatible next."""
+
+        return self.iternext()
+
+    def previous(self):
+        """Get previous char."""
+
+        return self.string[self.index - 1]
+
+    def rewind(self, count):
+        """Rewind index."""
+
+        self.index -= count
+
+    def iternext(self):
+        """Iterate through characters of the string."""
+
+        if self.index > self.max_index:
+            raise StopIteration
+
+        char = self.string[self.index]
+        self.index += 1
+
+        return char
+
+    # Python 2 iterator compatible next.
+    next = __next__  # noqa A002
+
+
+class Wildcard2Regex(object):
+    """Translate fnmatch pattern to regex."""
+
+    def __init__(self, pattern, regex_mode=RE_MODE, case_sensitive=False):
+        """Initialize."""
+
+        self.pattern = pattern
+        if (regex_mode in REGEX_MODES and not REGEX_SUPPORT) or (RE_MODE > regex_mode > BREGEX_MODE):
+            regex_mode = RE_MODE
+        self.engine = regex if regex_mode in REGEX_MODES else re
+        self.flags = 0
+        if regex_mode:
+            self.flags |= self.engine.V0
+        if not case_sensitive:
+            self.flags |= self.engine.I
+
+    def _character_group(self, i):
+        """Handle fnmatch character group."""
+
+        result = ['[']
+
+        c = next(i)
+        if c == '!':
+            # Handle negate char
+            result.append('^')
+            c = next(i)
+        if c == '^':
+            # Escape regular expression negate character
+            result.append('\\' + c)
+            c = next(i)
+        elif c == ']':
+            # Handle closing as first character
+            result.append(c)
+            c = next(i)
+
+        end_stored = False
+        while c != ']':
+            if c == '\\':
+                subindex = i.index
+                try:
+                    result.append(self.references(i))
+                    if i.previous() == ']':
+                        end_stored = True
+                        break
+                except StopIteration:
+                    i.rewind(i.index - subindex)
+                    result.append('\\\\')
+            else:
+                result.append(c)
+            c = next(i)
+
+        if not end_stored:
+            result.append(']')
+
+        return ''.join(result)
+
+    def references(self, i):
+        """Handle references."""
+
+        value = ''
+        c = next(i)
+        if c in 'N':
+            c = next(i)
+            if c != '{':
+                raise SyntaxError('Invalid named character format at %d!' % (i.index - 1))
+            name = []
+            c = next(i)
+            while c != '}':
+                name.append(c)
+                c = next(i)
+            nval = ord(unicodedata.lookup(''.join(name)))
+            value = '\\%03o' % nval if nval <= 0xFF else backrefs.util.uchr(nval)
+        elif c in _OCTAL or c in _STANDARD_ESCAPES or c in _CHAR_ESCAPES:
+            value = '\\' + c
+        else:
+            value = '\\\\' + c
+        return value
+
+    def translate(self):
+        """Translate fnmatch pattern counting `|` as a separator."""
+
+        result = []
+        exclude_result = []
+
+        exclude_mode = self.pattern[0] == '-'
+        skip_first = exclude_mode
+
+        i = _StringIter(self.pattern)
+        iter(i)
+        for c in i:
+            if skip_first:
+                skip_first = False
+                continue
+            current = exclude_result if exclude_mode else result
+            if c == '*':
+                current.append('.*')
+            elif c == '?':
+                current.append('.')
+            elif c == '|':
+                current.append(c)
+                try:
+                    c = next(i)
+                    if c == '-':
+                        exclude_mode = True
+                    else:
+                        exclude_mode = False
+                        i.rewind(1)
+                except StopIteration:
+                    i.rewind(1)
+                    exclude_mode = False
+            elif c == '\\':
+                index = i.index
+                try:
+                    current.append(self.references(i))
+                except StopIteration:
+                    i.rewind(i.index - index)
+                    current.append('\\\\')
+            elif c == '[':
+                index = i.index
+                try:
+                    current.append(self._character_group(i))
+                except StopIteration:
+                    i.rewind(i.index - index)
+                    current.append('\\[')
+            else:
+                current.append(self.engine.escape(c))
+        if util.PY36:
+            pattern = r'(?s:%s)\Z' % ''.join(result)
+            exclude_pattern = r'(?s:%s)\Z' % ''.join(exclude_result)
+        else:
+            pattern = r'(?ms)(?:%s)\Z' % ''.join(result)
+            exclude_pattern = r'(?ms)(?:%s)\Z' % ''.join(exclude_result)
+
+        print(pattern, exclude_pattern)
+
+        return self.engine.compile(pattern, self.flags), self.engine.compile(exclude_pattern, self.flags)
 
 
 class Search(object):
@@ -1203,10 +1391,8 @@ class _DirWalker(object):
         self.size = (size[0], size[1]) if size is not None else size
         self.modified = modified
         self.created = created
-        self.file_pattern = self._parse_pattern(file_pattern, file_regex_match)
-        self.file_regex_match = file_regex_match
-        self.dir_regex_match = dir_regex_match
-        self.folder_exclude = self._parse_pattern(folder_exclude, dir_regex_match)
+        self.file_pattern, self.exclude_file_pattern = self._parse_pattern(file_pattern, file_regex_match)
+        self.folder_exclude, self.negated_folder_exclude = self._parse_pattern(folder_exclude, dir_regex_match)
         self.recursive = recursive
         self.show_hidden = show_hidden
         self.backup2folder = backup_to_folder
@@ -1221,24 +1407,28 @@ class _DirWalker(object):
         r"""Compile or format the inclusion\exclusion pattern."""
 
         pattern = None
-        if string is not None:
-            if self.regex_mode == BREGEX_MODE:
-                pattern = bregex.compile_search(
-                    string, bregex.IGNORECASE
-                ) if regex_match else [f.lower() for f in string.split("|")]
-            elif self.regex_mode == REGEX_MODE:
-                pattern = regex.compile(
-                    string, regex.IGNORECASE | regex.ASCII
-                ) if regex_match else [f.lower() for f in string.split("|")]
-            elif self.regex_mode == BRE_MODE:
-                pattern = bre.compile_search(
-                    string, bre.IGNORECASE | (bre.ASCII if util.PY3 else 0)
-                ) if regex_match else [f.lower() for f in string.split("|")]
-            else:
-                pattern = re.compile(
-                    string, re.IGNORECASE | (re.ASCII if util.PY3 else 0)
-                ) if regex_match else [f.lower() for f in string.split("|")]
-        return pattern
+        exclude_pattern = None
+        if regex_match:
+            if string is not None:
+                if self.regex_mode == BREGEX_MODE:
+                    pattern = bregex.compile_search(
+                        string, bregex.IGNORECASE
+                    )
+                elif self.regex_mode == REGEX_MODE:
+                    pattern = regex.compile(
+                        string, regex.IGNORECASE | regex.ASCII
+                    )
+                elif self.regex_mode == BRE_MODE:
+                    pattern = bre.compile_search(
+                        string, bre.IGNORECASE | (bre.ASCII if util.PY3 else 0)
+                    )
+                else:
+                    pattern = re.compile(
+                        string, re.IGNORECASE | (re.ASCII if util.PY3 else 0)
+                    )
+        elif string is not None:
+            pattern, exclude_pattern = Wildcard2Regex(string, self.regex_mode).translate()
+        return pattern, exclude_pattern
 
     def _is_hidden(self, path):
         """Check if file is hidden."""
@@ -1324,22 +1514,9 @@ class _DirWalker(object):
             not self._is_hidden(os.path.join(base, name)) and
             not self._is_backup(name)
         ):
-            if self.file_regex_match:
-                valid = True if self.file_pattern.match(name) is not None else False
-            else:
-                matched = False
-                exclude = False
-                for p in self.file_pattern:
-                    if len(p) > 1 and p[0] == "-":
-                        if fnmatch(name.lower(), p[1:]):
-                            exclude = True
-                            break
-                    elif fnmatch(name.lower(), p):
-                        matched = True
-                if exclude:
-                    valid = False
-                elif matched:
-                    valid = True
+            valid = self.file_pattern.match(name) is not None
+            if self.exclude_file_pattern and self.exclude_file_pattern.match(name) is not None:
+                valid = False
             if valid:
                 valid = self._is_size_okay(os.path.join(base, name))
             if valid:
@@ -1355,22 +1532,9 @@ class _DirWalker(object):
         elif self._is_hidden(os.path.join(base, name)) or self._is_backup(name, True):
             valid = False
         elif self.folder_exclude is not None:
-            if self.dir_regex_match:
-                valid = False if self.folder_exclude.match(name) is not None else True
-            else:
-                matched = False
-                exclude = False
-                for p in self.folder_exclude:
-                    if len(p) > 1 and p[0] == "-":
-                        if fnmatch(name.lower(), p[1:]):
-                            matched = True
-                            break
-                    elif fnmatch(name.lower(), p):
-                        exclude = True
-                if matched:
-                    valid = True
-                elif exclude:
-                    valid = False
+            valid = self.folder_exclude.match(name) is None
+            if self.negated_folder_exclude is not None and self.negated_folder_exclude.match(name) is not None:
+                valid = True
         return valid
 
     def kill(self):

--- a/rummage/lib/util/__init__.py
+++ b/rummage/lib/util/__init__.py
@@ -18,6 +18,7 @@ NARROW = sys.maxunicode == 0xFFFF
 
 PY3 = (3, 0) <= sys.version_info
 PY2 = (2, 0) <= sys.version_info < (3, 0)
+PY36 = (3, 6) <= sys.version_info
 
 if sys.platform.startswith('win'):
     _PLATFORM = "windows"


### PR DESCRIPTION
Handle pattern separators properly and allow character notations for things like \xXX or \uXXXX etc. Fix documentation in regards to wildcard patterns and better explain what the wildcard rules are.

Ref #193 