### PR TITLE
Better wildcard handling

### DIFF
--- a/tests/test_rumcore.py
+++ b/tests/test_rumcore.py
@@ -24,15 +24,15 @@ class TestWildcard(unittest.TestCase):
     def test_wildcard_parsing(self):
         """Test wildcard parsing."""
 
-        p1, p2 = rc.Wildcard2Regex(r'*test[a-z]?|*test2[a-z]?|-test[!a-z]|-test[!-|a-z]').translate()
+        p1, p2 = rc.Wildcard2Regex('*test[a-z]?|*test2[a-z]?|-test[!a-z]|-test[!-|a-z]').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:.*test[a-z].|.*test2[a-z].)\Z')
-            self.assertEqual(p2.pattern, r'(?s:test[^a-z]|test[^-|a-z])\Z')
+            self.assertEqual(p2.pattern, r'(?s:test[^a-z]|test[^\-\|a-z])\Z')
         else:
             self.assertEqual(p1.pattern, r'(?ms)(?:.*test[a-z].|.*test2[a-z].)\Z')
-            self.assertEqual(p2.pattern, r'(?ms)(?:test[^a-z]|test[^-|a-z])\Z')
+            self.assertEqual(p2.pattern, r'(?ms)(?:test[^a-z]|test[^\-\|a-z])\Z')
 
-        p1, p2 = rc.Wildcard2Regex(r'test[]][!][][]').translate()
+        p1, p2 = rc.Wildcard2Regex('test[]][!][][]').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:test[]][^][]\[\])\Z')
             self.assertEqual(p2.pattern, r'(?s:)\Z')
@@ -40,7 +40,7 @@ class TestWildcard(unittest.TestCase):
             self.assertEqual(p1.pattern, r'(?ms)(?:test[]][^][]\[\])\Z')
             self.assertEqual(p2.pattern, r'(?ms)(?:)\Z')
 
-        p1, p2 = rc.Wildcard2Regex(r'test[!]').translate()
+        p1, p2 = rc.Wildcard2Regex('test[!]').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:test\[\!\])\Z')
             self.assertEqual(p2.pattern, r'(?s:)\Z')
@@ -48,7 +48,7 @@ class TestWildcard(unittest.TestCase):
             self.assertEqual(p1.pattern, r'(?ms)(?:test\[\!\])\Z')
             self.assertEqual(p2.pattern, r'(?ms)(?:)\Z')
 
-        p1, p2 = rc.Wildcard2Regex(r'|test|').translate()
+        p1, p2 = rc.Wildcard2Regex('|test|').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:|test|)\Z')
             self.assertEqual(p2.pattern, r'(?s:)\Z')
@@ -56,7 +56,7 @@ class TestWildcard(unittest.TestCase):
             self.assertEqual(p1.pattern, r'(?ms)(?:|test|)\Z')
             self.assertEqual(p2.pattern, r'(?ms)(?:)\Z')
 
-        p1, p2 = rc.Wildcard2Regex(r'-|-test|-').translate()
+        p1, p2 = rc.Wildcard2Regex('-|-test|-').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:)\Z')
             self.assertEqual(p2.pattern, r'(?s:|test|)\Z')
@@ -64,13 +64,26 @@ class TestWildcard(unittest.TestCase):
             self.assertEqual(p1.pattern, r'(?ms)(?:)\Z')
             self.assertEqual(p2.pattern, r'(?ms)(?:|test|)\Z')
 
-        p1, p2 = rc.Wildcard2Regex(r'test[^chars]').translate()
+        p1, p2 = rc.Wildcard2Regex('test[^chars]').translate()
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:test[\^chars])\Z')
             self.assertEqual(p2.pattern, r'(?s:)\Z')
         else:
             self.assertEqual(p1.pattern, r'(?ms)(?:test[\^chars])\Z')
             self.assertEqual(p2.pattern, r'(?ms)(?:)\Z')
+
+        p1 = rc.Wildcard2Regex(r'test[^\-\&]').translate()[0]
+        if util.PY36:
+            self.assertEqual(p1.pattern, r'(?s:test[\^\\-\\\&])\Z')
+        else:
+            self.assertEqual(p1.pattern, r'(?ms)(?:test[\^\\-\\\&])\Z')
+
+        self.assertTrue(rc.Wildcard2Regex('[[]').translate()[0].match('[') is not None)
+        self.assertTrue(rc.Wildcard2Regex('[a&&b]').translate()[0].match('&') is not None)
+        self.assertTrue(rc.Wildcard2Regex('[a||b]').translate()[0].match('|') is not None)
+        self.assertTrue(rc.Wildcard2Regex('[a~~b]').translate()[0].match('~') is not None)
+        self.assertTrue(rc.Wildcard2Regex('[a-z+--A-Z]').translate()[0].match(',') is not None)
+        self.assertTrue(rc.Wildcard2Regex('[a-z--/A-Z]').translate()[0].match('.') is not None)
 
     def test_wildcard_character_notation(self):
         """Test wildcard character notations."""


### PR DESCRIPTION
Escape `&|~-` because future Python versions will handle these differently.  Handle hypens properly as they can also be range delimiters.