### PR TITLE
Wildcard escape considerations

### DIFF
--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -312,7 +312,7 @@ Pattern  | Meaning
 `|`      | Separates multiple patterns.
 `-`      | If used at the start of a pattern, the pattern is treated as an exception to other applied patterns.
 
-You can also use Python notation for specifying characters to make things like Unicode character input easier. So you can use `\x70`, `\u0070`, `\160`, for bytes, Unicode, or octal style character notation. You can also use Unicode names: `\N{unicode name}`.
+You can also use Python character escapes to make things like Unicode character input easier. So you can use `\x70`, `\u0070`, `\U00000070`, and `\160`, for bytes, Unicode, 32 bit Unicode, or octal style character notation. You can also use Unicode names: `\N{unicode name}` and standard Python character escapes like `\t` etc. You can also escape the the backslash to avoid special escapes: `\\`.
 
 !!! example "Example Patterns"
 

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -95,9 +95,10 @@ DEFAULT_BAK = 'rum-bak'
 DEFAULT_FOLDER_BAK = '.rum-bak'
 
 _OCTAL = frozenset(('0', '1', '2', '3', '4', '5', '6', '7'))
-_STANDARD_ESCAPES = frozenset(('a', 'b', 'f', 'n', 'r', 't', 'v'))
+_STANDARD_ESCAPES = frozenset(('a', 'b', 'f', 'n', 'r', 't', 'v', '\\'))
 _CHAR_ESCAPES = frozenset(('u', 'U', 'x'))
 _SET_OPERATORS = frozenset(('&', '~', '|'))
+_WILDCARD_CHARS = frozenset(('-', '[', ']', '*', '?', '|'))
 
 U32 = (
     'u32', 'utf32', 'utf_32'
@@ -520,7 +521,7 @@ class Wildcard2Regex(object):
         elif c in _STANDARD_ESCAPES or c in _CHAR_ESCAPES:
             # \n, \v, etc. and \u, \U, \x etc.
             value = '\\' + c
-        elif c in _SET_OPERATORS or c == '-':
+        elif c in _SET_OPERATORS or c in _WILDCARD_CHARS:
             value = '\\\\'
             i.rewind(1)
         else:

--- a/tests/test_rumcore.py
+++ b/tests/test_rumcore.py
@@ -88,7 +88,7 @@ class TestWildcard(unittest.TestCase):
         if util.PY36:
             self.assertEqual(p1.pattern, r'(?s:\\u0300)\Z')
         else:
-            self.assertEqual(p1.pattern, r'(?ms)(?:\\.*\\.\\[\\])\Z')
+            self.assertEqual(p1.pattern, r'(?ms)(?:\\u0300)\Z')
 
         self.assertTrue(rc.Wildcard2Regex(r'test\test').translate()[0].match('test\test') is not None)
         self.assertTrue(rc.Wildcard2Regex(r'test\\test').translate()[0].match('test\\test') is not None)

--- a/tests/test_rumcore.py
+++ b/tests/test_rumcore.py
@@ -78,6 +78,23 @@ class TestWildcard(unittest.TestCase):
         else:
             self.assertEqual(p1.pattern, r'(?ms)(?:test[\^\\-\\\&])\Z')
 
+        p1 = rc.Wildcard2Regex(r'\*\?\|\[\]').translate()[0]
+        if util.PY36:
+            self.assertEqual(p1.pattern, r'(?s:\\.*\\.\\|\\[\\])\Z')
+        else:
+            self.assertEqual(p1.pattern, r'(?ms)(?:\\.*\\.\\|\\[\\])\Z')
+
+        p1 = rc.Wildcard2Regex(r'\\u0300').translate()[0]
+        if util.PY36:
+            self.assertEqual(p1.pattern, r'(?s:\\u0300)\Z')
+        else:
+            self.assertEqual(p1.pattern, r'(?ms)(?:\\.*\\.\\[\\])\Z')
+
+        self.assertTrue(rc.Wildcard2Regex(r'test\test').translate()[0].match('test\test') is not None)
+        self.assertTrue(rc.Wildcard2Regex(r'test\\test').translate()[0].match('test\\test') is not None)
+        self.assertTrue(rc.Wildcard2Regex(r'test\m').translate()[0].match('test\\m') is not None)
+        self.assertTrue(rc.Wildcard2Regex(r'test\[a-z]').translate()[0].match('test\\b') is not None)
+        self.assertTrue(rc.Wildcard2Regex(r'test\\[a-z]').translate()[0].match('test\\b') is not None)
         self.assertTrue(rc.Wildcard2Regex('[[]').translate()[0].match('[') is not None)
         self.assertTrue(rc.Wildcard2Regex('[a&&b]').translate()[0].match('&') is not None)
         self.assertTrue(rc.Wildcard2Regex('[a||b]').translate()[0].match('|') is not None)


### PR DESCRIPTION
More wildcard considerations.  Ensure backslash does not consume special wildcard characters. Ensure we handle escaped backslashes properly: `\\`.