### PR TITLE
Cleanup objects

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.0.1
+
+- **FIX**: Cleanup some object leaks.
+- **FIX**: Incorrect sizing of chain dialog.
+
 ## 4.0.0
 
 Feb 18, 2018

--- a/gui.fbp
+++ b/gui.fbp
@@ -8917,7 +8917,7 @@
             <event name="OnAuiPaneRestore"></event>
             <event name="OnAuiRender"></event>
             <event name="OnChar"></event>
-            <event name="OnClose"></event>
+            <event name="OnClose">on_close</event>
             <event name="OnEnterWindow"></event>
             <event name="OnEraseBackground"></event>
             <event name="OnHibernate"></event>
@@ -19787,7 +19787,7 @@
             <event name="OnAuiPaneRestore"></event>
             <event name="OnAuiRender"></event>
             <event name="OnChar"></event>
-            <event name="OnClose"></event>
+            <event name="OnClose">on_close</event>
             <event name="OnEnterWindow"></event>
             <event name="OnEraseBackground"></event>
             <event name="OnHibernate"></event>
@@ -20404,7 +20404,7 @@
             <property name="hidden">0</property>
             <property name="id">wxID_ANY</property>
             <property name="maximum_size"></property>
-            <property name="minimum_size"></property>
+            <property name="minimum_size">470,288</property>
             <property name="name">SearchChainDialog</property>
             <property name="pos"></property>
             <property name="size">470,288</property>
@@ -20424,7 +20424,7 @@
             <event name="OnAuiPaneRestore"></event>
             <event name="OnAuiRender"></event>
             <event name="OnChar"></event>
-            <event name="OnClose"></event>
+            <event name="OnClose">on_close</event>
             <event name="OnEnterWindow"></event>
             <event name="OnEraseBackground"></event>
             <event name="OnHibernate"></event>
@@ -22118,7 +22118,7 @@
             <event name="OnAuiPaneRestore"></event>
             <event name="OnAuiRender"></event>
             <event name="OnChar"></event>
-            <event name="OnClose"></event>
+            <event name="OnClose">on_close</event>
             <event name="OnEnterWindow"></event>
             <event name="OnEraseBackground"></event>
             <event name="OnHibernate"></event>

--- a/gui.fbp
+++ b/gui.fbp
@@ -10957,7 +10957,7 @@
                                                     <property name="border">5</property>
                                                     <property name="flag">wxALL|wxEXPAND</property>
                                                     <property name="proportion">1</property>
-                                                    <object class="wxListCtrl" expanded="0">
+                                                    <object class="CustomControl" expanded="0">
                                                         <property name="BottomDockable">1</property>
                                                         <property name="LeftDockable">1</property>
                                                         <property name="RightDockable">1</property>
@@ -10971,9 +10971,12 @@
                                                         <property name="caption"></property>
                                                         <property name="caption_visible">1</property>
                                                         <property name="center_pane">0</property>
+                                                        <property name="class">wxListCtrl</property>
                                                         <property name="close_button">1</property>
+                                                        <property name="construction">self.m_encoding_list = EncodingList(self.m_encoding_panel)</property>
                                                         <property name="context_help"></property>
                                                         <property name="context_menu">1</property>
+                                                        <property name="declaration"></property>
                                                         <property name="default_pane">0</property>
                                                         <property name="dock">Dock</property>
                                                         <property name="dock_fixed">0</property>
@@ -10985,6 +10988,7 @@
                                                         <property name="gripper">0</property>
                                                         <property name="hidden">0</property>
                                                         <property name="id">wxID_ANY</property>
+                                                        <property name="include">from .controls.encoding_list import EncodingList</property>
                                                         <property name="max_size"></property>
                                                         <property name="maximize_button">0</property>
                                                         <property name="maximum_size"></property>
@@ -10992,7 +10996,7 @@
                                                         <property name="minimize_button">0</property>
                                                         <property name="minimum_size"></property>
                                                         <property name="moveable">1</property>
-                                                        <property name="name">m_filetype_listctrl</property>
+                                                        <property name="name">m_encoding_list</property>
                                                         <property name="pane_border">1</property>
                                                         <property name="pane_position"></property>
                                                         <property name="pane_size"></property>
@@ -11000,16 +11004,12 @@
                                                         <property name="pin_button">1</property>
                                                         <property name="pos"></property>
                                                         <property name="resize">Resizable</property>
+                                                        <property name="settings"></property>
                                                         <property name="show">1</property>
                                                         <property name="size"></property>
-                                                        <property name="style">wxLC_REPORT</property>
-                                                        <property name="subclass"></property>
+                                                        <property name="subclass">; forward_declare</property>
                                                         <property name="toolbar_pane">0</property>
                                                         <property name="tooltip"></property>
-                                                        <property name="validator_data_type"></property>
-                                                        <property name="validator_style">wxFILTER_NONE</property>
-                                                        <property name="validator_type">wxDefaultValidator</property>
-                                                        <property name="validator_variable"></property>
                                                         <property name="window_extra_style"></property>
                                                         <property name="window_name"></property>
                                                         <property name="window_style"></property>
@@ -11020,29 +11020,9 @@
                                                         <event name="OnKeyUp"></event>
                                                         <event name="OnKillFocus"></event>
                                                         <event name="OnLeaveWindow"></event>
-                                                        <event name="OnLeftDClick">on_dclick</event>
+                                                        <event name="OnLeftDClick"></event>
                                                         <event name="OnLeftDown"></event>
                                                         <event name="OnLeftUp"></event>
-                                                        <event name="OnListBeginDrag"></event>
-                                                        <event name="OnListBeginLabelEdit"></event>
-                                                        <event name="OnListBeginRDrag"></event>
-                                                        <event name="OnListCacheHint"></event>
-                                                        <event name="OnListColBeginDrag"></event>
-                                                        <event name="OnListColClick"></event>
-                                                        <event name="OnListColDragging"></event>
-                                                        <event name="OnListColEndDrag"></event>
-                                                        <event name="OnListColRightClick"></event>
-                                                        <event name="OnListDeleteAllItems"></event>
-                                                        <event name="OnListDeleteItem"></event>
-                                                        <event name="OnListEndLabelEdit"></event>
-                                                        <event name="OnListInsertItem"></event>
-                                                        <event name="OnListItemActivated"></event>
-                                                        <event name="OnListItemDeselected"></event>
-                                                        <event name="OnListItemFocused"></event>
-                                                        <event name="OnListItemMiddleClick"></event>
-                                                        <event name="OnListItemRightClick"></event>
-                                                        <event name="OnListItemSelected"></event>
-                                                        <event name="OnListKeyDown"></event>
                                                         <event name="OnMiddleDClick"></event>
                                                         <event name="OnMiddleDown"></event>
                                                         <event name="OnMiddleUp"></event>

--- a/rummage/lib/gui/controls/dynamic_lists.py
+++ b/rummage/lib/gui/controls/dynamic_lists.py
@@ -85,6 +85,11 @@ class DynamicList(wx.ListCtrl, listmix.ColumnSorterMixin):
         self.setup_columns()
         self.itemIndexMap = []
 
+    def destroy(self):
+        """Destroy."""
+
+        self.dc.Destroy()
+
     def set_keybindings(self, keybindings=None):
         """
         Method to easily set key bindings.

--- a/rummage/lib/gui/controls/encoding_list.py
+++ b/rummage/lib/gui/controls/encoding_list.py
@@ -1,0 +1,67 @@
+"""
+Encoding list.
+
+Licensed under MIT
+Copyright (c) 2013 - 2018 Isaac Muse <isaacmuse@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+import wx
+from .dynamic_lists import DynamicList
+from ..localization import _
+from .. import data
+
+
+class EncodingList(DynamicList):
+    """Encoding list."""
+
+    def __init__(self, parent):
+        """Initialization."""
+
+        self.localize()
+
+        super(EncodingList, self).__init__(
+            parent,
+            [
+                self.FILE_TYPE,
+                self.EXTENSIONS
+            ]
+        )
+
+    def localize(self):
+        """Translate strings."""
+
+        self.FILE_TYPE = _("File type")
+        self.EXTENSIONS = _("Extensions")
+
+    def create_image_list(self):
+        """Create image list."""
+
+        self.images = wx.ImageList(16, 16)
+        self.sort_up = self.images.Add(data.get_bitmap('su.png'))
+        self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
+
+    def get_item_text(self, item, col, absolute=False):
+        """Return the text for the given item and col."""
+
+        if not absolute:
+            item = self.itemIndexMap[item]
+        return self.itemDataMap[item][col]
+
+    def OnGetItemImage(self, item):
+        """Override method to get the image for the given item."""
+
+        return -1

--- a/rummage/lib/gui/controls/encoding_list.py
+++ b/rummage/lib/gui/controls/encoding_list.py
@@ -50,6 +50,8 @@ class EncodingList(DynamicList):
         """Create image list."""
 
         self.images = wx.ImageList(16, 16)
+        self.doc = self.images.Add(data.get_bitmap('doc.png'))
+        self.bin = self.images.Add(data.get_bitmap('binary.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
         self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
@@ -64,4 +66,4 @@ class EncodingList(DynamicList):
     def OnGetItemImage(self, item):
         """Override method to get the image for the given item."""
 
-        return -1
+        return self.bin if self.itemIndexMap[item] == 'bin' else self.doc

--- a/rummage/lib/gui/controls/load_search_list.py
+++ b/rummage/lib/gui/controls/load_search_list.py
@@ -63,7 +63,7 @@ class SavedSearchList(DynamicList):
         self.glass = self.images.Add(data.get_bitmap('glass.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
-        self.SetImageList(self.images, wx.IMAGE_LIST_SMALL)
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
 
     def get_item_text(self, item, col, absolute=False):
         """Return the text for the given item and col."""

--- a/rummage/lib/gui/controls/result_lists.py
+++ b/rummage/lib/gui/controls/result_lists.py
@@ -150,7 +150,7 @@ class ResultFileList(DynamicList):
         self.bin = self.images.Add(data.get_bitmap('binary.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
-        self.SetImageList(self.images, wx.IMAGE_LIST_SMALL)
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
 
     def set_match(self, obj, file_search=False):
         """Set match."""
@@ -439,7 +439,7 @@ class ResultContentList(DynamicList):
         self.bin = self.images.Add(data.get_bitmap('binary.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
-        self.SetImageList(self.images, wx.IMAGE_LIST_SMALL)
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
 
     def on_enter_window(self, event):
         """Reset last moused over item tracker on mouse entering the window."""

--- a/rummage/lib/gui/controls/search_chain_list.py
+++ b/rummage/lib/gui/controls/search_chain_list.py
@@ -53,7 +53,7 @@ class SearchChainList(DynamicList):
         self.glass = self.images.Add(data.get_bitmap('glass.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
-        self.SetImageList(self.images, wx.IMAGE_LIST_SMALL)
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
 
     def get_item_text(self, item, col, absolute=False):
         """Return the text for the given item and col."""

--- a/rummage/lib/gui/controls/search_error_list.py
+++ b/rummage/lib/gui/controls/search_error_list.py
@@ -55,7 +55,7 @@ class ErrorList(DynamicList):
         self.error_symbol = self.images.Add(data.get_bitmap('error.png'))
         self.sort_up = self.images.Add(data.get_bitmap('su.png'))
         self.sort_down = self.images.Add(data.get_bitmap('sd.png'))
-        self.SetImageList(self.images, wx.IMAGE_LIST_SMALL)
+        self.AssignImageList(self.images, wx.IMAGE_LIST_SMALL)
 
     def get_item_text(self, item, col, absolute=False):
         """Return the text for the given item and col."""

--- a/rummage/lib/gui/gui.py
+++ b/rummage/lib/gui/gui.py
@@ -14,6 +14,7 @@ from .controls.date_picker import DatePicker
 from wx.lib.masked import TimeCtrl
 from .controls.result_lists import ResultFileList
 from .controls.result_lists import ResultContentList
+from .controls.encoding_list import EncodingList
 from .controls.load_search_list import SavedSearchList
 from .controls.search_chain_list import SearchChainList
 from .controls.list_box import ListBox
@@ -1095,8 +1096,8 @@ class SettingsDialog ( wx.Dialog ):
 		self.m_filetype_label.Wrap( -1 )
 		fgSizer57.Add( self.m_filetype_label, 0, wx.ALL, 5 )
 		
-		self.m_filetype_listctrl = wx.ListCtrl( self.m_encoding_panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LC_REPORT )
-		fgSizer57.Add( self.m_filetype_listctrl, 1, wx.ALL|wx.EXPAND, 5 )
+		self.m_encoding_list = EncodingList(self.m_encoding_panel)
+		fgSizer57.Add( self.m_encoding_list, 1, wx.ALL|wx.EXPAND, 5 )
 		
 		
 		self.m_encoding_panel.SetSizer( fgSizer57 )
@@ -1280,7 +1281,6 @@ class SettingsDialog ( wx.Dialog ):
 		self.m_bregex_radio.Bind( wx.EVT_RADIOBUTTON, self.on_bregex_toggle )
 		self.m_regex_ver_choice.Bind( wx.EVT_CHOICE, self.on_regex_ver_choice )
 		self.m_encoding_choice.Bind( wx.EVT_CHOICE, self.on_chardet )
-		self.m_filetype_listctrl.Bind( wx.EVT_LEFT_DCLICK, self.on_dclick )
 		self.m_editor_button.Bind( wx.EVT_BUTTON, self.on_editor_change )
 		self.m_visual_alert_checkbox.Bind( wx.EVT_CHECKBOX, self.on_notify_toggle )
 		self.m_notify_choice.Bind( wx.EVT_CHOICE, self.on_notify_choice )
@@ -1333,9 +1333,6 @@ class SettingsDialog ( wx.Dialog ):
 		event.Skip()
 	
 	def on_chardet( self, event ):
-		event.Skip()
-	
-	def on_dclick( self, event ):
 		event.Skip()
 	
 	def on_editor_change( self, event ):

--- a/rummage/lib/gui/gui.py
+++ b/rummage/lib/gui/gui.py
@@ -1268,6 +1268,7 @@ class SettingsDialog ( wx.Dialog ):
 		self.Centre( wx.BOTH )
 		
 		# Connect Events
+		self.Bind( wx.EVT_CLOSE, self.on_close )
 		self.m_single_checkbox.Bind( wx.EVT_CHECKBOX, self.on_single_toggle )
 		self.m_lang_choice.Bind( wx.EVT_CHOICE, self.on_language )
 		self.m_update_checkbox.Bind( wx.EVT_CHECKBOX, self.on_update_toggle )
@@ -1298,6 +1299,9 @@ class SettingsDialog ( wx.Dialog ):
 	
 	
 	# Virtual event handlers, overide them in your derived class
+	def on_close( self, event ):
+		event.Skip()
+	
 	def on_single_toggle( self, event ):
 		event.Skip()
 	
@@ -2209,6 +2213,7 @@ class LoadSearchDialog ( wx.Dialog ):
 		self.Centre( wx.BOTH )
 		
 		# Connect Events
+		self.Bind( wx.EVT_CLOSE, self.on_close )
 		self.m_edit_button.Bind( wx.EVT_BUTTON, self.on_edit_click )
 		self.m_delete_button.Bind( wx.EVT_BUTTON, self.on_delete )
 		self.m_load_button.Bind( wx.EVT_BUTTON, self.on_load )
@@ -2219,6 +2224,9 @@ class LoadSearchDialog ( wx.Dialog ):
 	
 	
 	# Virtual event handlers, overide them in your derived class
+	def on_close( self, event ):
+		event.Skip()
+	
 	def on_edit_click( self, event ):
 		event.Skip()
 	
@@ -2241,7 +2249,7 @@ class SearchChainDialog ( wx.Dialog ):
 	def __init__( self, parent ):
 		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Search Chains", pos = wx.DefaultPosition, size = wx.Size( 470,288 ), style = wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
 		
-		self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
+		self.SetSizeHints( wx.Size( 470,288 ), wx.DefaultSize )
 		
 		bSizer16 = wx.BoxSizer( wx.VERTICAL )
 		
@@ -2298,6 +2306,7 @@ class SearchChainDialog ( wx.Dialog ):
 		self.Centre( wx.BOTH )
 		
 		# Connect Events
+		self.Bind( wx.EVT_CLOSE, self.on_close )
 		self.m_add_button.Bind( wx.EVT_BUTTON, self.on_add_click )
 		self.m_edit_button.Bind( wx.EVT_BUTTON, self.on_edit_click )
 		self.m_remove_button.Bind( wx.EVT_BUTTON, self.on_remove_click )
@@ -2308,6 +2317,9 @@ class SearchChainDialog ( wx.Dialog ):
 	
 	
 	# Virtual event handlers, overide them in your derived class
+	def on_close( self, event ):
+		event.Skip()
+	
 	def on_add_click( self, event ):
 		event.Skip()
 	
@@ -2491,9 +2503,17 @@ class SearchErrorDialog ( wx.Dialog ):
 		self.Layout()
 		
 		self.Centre( wx.BOTH )
+		
+		# Connect Events
+		self.Bind( wx.EVT_CLOSE, self.on_close )
 	
 	def __del__( self ):
 		pass
+	
+	
+	# Virtual event handlers, overide them in your derived class
+	def on_close( self, event ):
+		event.Skip()
 	
 
 ###########################################################################

--- a/rummage/lib/gui/load_search_dialog.py
+++ b/rummage/lib/gui/load_search_dialog.py
@@ -188,3 +188,9 @@ class LoadSearchDialog(gui.LoadSearchDialog):
         """Close dialog."""
 
         self.Close()
+
+    def on_close(self, event):
+        """Handle on close event."""
+
+        self.m_search_list.destroy()
+        event.Skip()

--- a/rummage/lib/gui/load_search_dialog.py
+++ b/rummage/lib/gui/load_search_dialog.py
@@ -98,7 +98,7 @@ class LoadSearchDialog(gui.LoadSearchDialog):
                 replace_type
             )
             count += 1
-        self.m_search_list.load_list()
+        self.m_search_list.load_list(True)
 
     def edit(self, item):
         """Edit the saved search."""

--- a/rummage/lib/gui/rummage_dialog.py
+++ b/rummage/lib/gui/rummage_dialog.py
@@ -2178,6 +2178,8 @@ class RummageFrame(gui.RummageFrame):
         if self.error_dlg is not None:
             self.error_dlg.Destroy()
             self.error_dlg = None
+        self.m_result_list.destroy()
+        self.m_result_file_list.destroy()
         self.m_statusbar.tear_down()
         notify.destroy_notifications()
         event.Skip()

--- a/rummage/lib/gui/search_chain_dialog.py
+++ b/rummage/lib/gui/search_chain_dialog.py
@@ -125,3 +125,9 @@ class SearchChainDialog(gui.SearchChainDialog):
         """Close window."""
 
         self.Close()
+
+    def on_close(self, event):
+        """Handle on close event."""
+
+        self.m_chain_list.destroy()
+        event.Skip()

--- a/rummage/lib/gui/search_chain_dialog.py
+++ b/rummage/lib/gui/search_chain_dialog.py
@@ -74,7 +74,7 @@ class SearchChainDialog(gui.SearchChainDialog):
             searches = ';'.join(c)
             self.m_chain_list.set_item_map(count, key, searches)
             count += 1
-        self.m_chain_list.load_list()
+        self.m_chain_list.load_list(True)
 
     def edit_chain(self, name=None):
         """Edit chain."""

--- a/rummage/lib/gui/search_error_dialog.py
+++ b/rummage/lib/gui/search_error_dialog.py
@@ -74,7 +74,7 @@ class SearchErrorDialog(gui.SearchErrorDialog):
             )
             self.m_error_list.set_item_map("%d" % count, e.error, name)
             count += 1
-        self.m_error_list.load_list()
+        self.m_error_list.load_list(True)
 
     def on_close(self, event):
         """Handle on close event."""

--- a/rummage/lib/gui/search_error_dialog.py
+++ b/rummage/lib/gui/search_error_dialog.py
@@ -75,3 +75,9 @@ class SearchErrorDialog(gui.SearchErrorDialog):
             self.m_error_list.set_item_map("%d" % count, e.error, name)
             count += 1
         self.m_error_list.load_list()
+
+    def on_close(self, event):
+        """Handle on close event."""
+
+        self.m_error_list.destroy()
+        event.Skip()

--- a/rummage/lib/gui/settings_dialog.py
+++ b/rummage/lib/gui/settings_dialog.py
@@ -446,6 +446,12 @@ class SettingsDialog(gui.SettingsDialog):
             mode = rumcore.RE_MODE
         Settings.set_regex_mode(mode)
 
+    def on_close(self, event):
+        """Handle on close event."""
+
+        self.dc.Destroy()
+        event.Skip()
+
     on_bregex_toggle = on_change_module
 
     on_regex_toggle = on_change_module

--- a/rummage/lib/gui/settings_dialog.py
+++ b/rummage/lib/gui/settings_dialog.py
@@ -398,17 +398,17 @@ class SettingsDialog(gui.SettingsDialog):
         """Handle double click."""
 
         pos = event.GetPosition()
-        item = self.HitTestSubItem(pos)[0]
+        item = self.m_encoding_list.HitTestSubItem(pos)[0]
         if item != -1:
-            key = self.GetItemText(item, 0)
-            extensions = self.GetItemText(item, 1)
+            key = self.m_encoding_list.GetItemText(item, 0)
+            extensions = self.m_encoding_list.GetItemText(item, 1)
             dlg = FileExtDialog(self, extensions)
             dlg.ShowModal()
             value = dlg.extensions
             dlg.Destroy()
             if extensions != value:
                 Settings.set_encoding_ext({key: value.split(', ')})
-                self.SetItem(item, 1, value)
+                self.m_encoding_list.SetItem(item, 1, value)
                 self.reload_list()
         event.Skip()
 


### PR DESCRIPTION
Cleanup ClientDC objects. 

Also wasn't aware, but image list needs to get cleaned up, so use AssignImageList to prevent leaking objects as it should auto clean up.

Unrelated, fix for chain dialog not being sized correctly