### PR TITLE
prep 4.2.1

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -24,6 +24,7 @@ JSON
 Jan
 Jul
 Jun
+KDE
 LF
 MERCHANTABILITY
 Mar
@@ -34,9 +35,11 @@ OS's
 OSD
 Oct
 OpenSSL
+PNG
 POSIX
 Plugin
 PyMdown
+PyPI
 Re
 Regex
 Regex's

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   - python: 3.6
     env: TOXENV=py36-unittests
   - python: 3.7
+    dist: xenial
     env: TOXENV=py37-unittests
   - python: 3.6
     env: TOXENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     env: TOXENV=py35-unittests
   - python: 3.6
     env: TOXENV=py36-unittests
-  - python: 3.7-dev
+  - python: 3.7
     env: TOXENV=py37-unittests
   - python: 3.6
     env: TOXENV=lint

--- a/docs/src/markdown/installation.md
+++ b/docs/src/markdown/installation.md
@@ -26,6 +26,12 @@ Name                   | Details
 
 Rummage requires wxPython in order ton run. On Linux, this must be compiled from source. Before running `pip`, you will have to install the appropriate prerequisites for your Linux distro. Rummage is generally tested on Ubuntu, so instructions are found. Remember, wxPython is a separate project and our instructions may get out of sync, so please check wxPython's official documentation on prerequisites before installing. Particularly under [this section](https://github.com/wxWidgets/Phoenix/blob/master/README.rst#prerequisites).
 
+Due to recent changes in PyPI, it is probably best to ensure you have at least version 10.0 or greater of `pip`.  Ubuntu provides a method for installing pip with `sudo apt-get install python3-pip`, but this is usually installs an older version.  It is recommended to install `pip` the command shown below (where `python3` is a call to the installed Python version of your choice):
+
+```
+curl https://bootstrap.pypa.io/get-pip.py | sudo python3
+```
+
 !!! info
     The latest wxPython Phoenix builds with GTK3 by default, so the example below will install GTK3 related dependencies. You can use GTK2 if you build wxPython manually.
 
@@ -33,10 +39,10 @@ Ubuntu
 : 
 
     ```bash
-    sudo apt-get install python3.5-dev dpkg-dev build-essential libwebkitgtk-dev libjpeg-dev libtiff-dev libsdl1.2-dev libgstreamer-plugins-base0.10-dev libnotify-dev freeglut3 freeglut3-dev libgtk-3-dev libwebkitgtk-3.0-dev
+    sudo apt-get install python3.6-dev dpkg-dev build-essential libwebkitgtk-dev libjpeg-dev libtiff-dev libsdl1.2-dev libgstreamer-plugins-base1.0-dev libnotify-dev freeglut3 freeglut3-dev libgtk-3-dev libwebkitgtk-3.0-dev
     ```
 
-    Replace `python3.5-dev` with the Python version you are using.
+    Replace `python3.6-dev` with the Python version you are using.
 
 Fedora 26
 : 
@@ -48,7 +54,11 @@ Fedora 26
 
     If your Linux distribution has `gstreamer` 1.0 available (like the Fedora distro), you can install the dev packages for that instead of the 0.10 version.
 
-After getting all the correct prerequisites, you should be able to install Rummage with `pip`. Be patient while installing Rummage. Linux must build wxPython while macOS and Windows do not. If installing with `pip`, you may be waiting a long time with no real indication of how far along the process is.  If `pip` doesn't work, you can look into building and installing manually.  If you find any of this information incorrect, please feel free to offer a pull request or create an issue on GitHub to at least report the problem.
+After getting all the correct prerequisites, you should be able to install Rummage with `pip`, though it is recommended to try and install wxPython first via `pip install wxpython`.
+
+If wxPython doesn't install properly, be sure to reference wxPython's documentation to see if there is something you are missing. Also, creating an issue over at wxPython's GitHub site for related wxPython install issues may get you help faster than creating them on the the Rummage issue page, which is mainly meant for tracking Rummage specific issues, not wxPython install issues.
+
+Be patient while installing wxPython as Linux must build wxPython while macOS and Windows do not. If installing with `pip`, you may be waiting a long time with no real indication of how far along the process is.  If `pip` doesn't work, you can look into building and installing manually.  If you find any of this information incorrect, please feel free to offer a pull request.
 
 ## macOS Prerequisites
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -697,7 +697,7 @@ Flags | Supported\ Libraries                       | Option
 
 There are many different flavors of Linux using different file managers.  This makes it difficult to give a guide to cover all cases.  Please research about your specific distro's file manager and how to add context menus.  If you would like to include the info here, please issue a pull request to update the documentation.
 
-#### Ubuntu Nautilus
+#### Ubuntu Nautilus (Gnome)
 
 Paths might vary depending on Ubuntu version etc.
 
@@ -718,6 +718,43 @@ Paths might vary depending on Ubuntu version etc.
     ```
 
 - Restart of Nautilus may or may not be needed, but context menu item should appear under `Scripts` and should work on files and folders.
+
+#### Ubuntu Dolphin (KDE)
+
+At the time of writing, this was tested on KDE 5, so most of the commands are appended with '5'.
+
+- To discover where you can store your context menu entries, run the following command:
+
+    ```
+    facelessuser@facelessuser:~$ kf5-config --path services
+    /home/facelessuser/.local/share/kservices5/:/usr/share/kservices5/
+    ```
+
+- Next create your `.desktop` file in one of these locations creating the necessary folder(s) if needed.  In this example, the file will be created at `~/.local/share/kservices5/ServiceMenus/rummage.desktoop`.
+
+- Provide the necessary configuration to specify the entry type, file targets, command to execute, icon, etc. In our case, we specify `all/all` to target both files and folders. We also point to one of the PNG files that ship in the package for the icon.
+
+    ```ini
+    [Desktop Entry]
+    Type=Service
+    X-KDE-ServiceTypes=KonqPopupMenu/Plugin
+    MimeType=all/all;
+    Actions=rummage
+
+    [Desktop Action rummage]
+    Name=Rummage Here...
+    Icon=/usr/local/lib/python3.5/dist-packages/rummage/lib/gui/data/rummage_hires.png
+    Exec=rummage --path "%f"
+    ```
+
+- Lastly we rebuild and refresh the desktop entries:
+
+    ```console
+    facelessuser@facelessuser:~$ kbuildsycoca5
+    ```
+
+- Close all Dolphin windows and reopen to see your context menu item.  It should be found under `Actions`.
+
 
 ## Localization
 


### PR DESCRIPTION
Update documentation to cover KDE menu adding. Clarify some wxPython installation things and stress that wxPython issues should be taken up with the wxPython repo (I don't have time to investigate  different distros installation requirements).