### PR TITLE
Make adjustments for wcmatch 2.0

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.4
+
+- **FIX**: Adjustments to work with `wcmatch` version 2.0.0.
+
 ## 4.2.3
 
 - **FIX**: Process preview in regular expression test dialog when replace pattern is empty. If replace plugin is enabled, we must have a plugin specified.

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -5,4 +5,4 @@ bracex
 wxpython>=4.0.1
 filelock
 send2trash
-wcmatch>=1.0.1,<2.0
+wcmatch>=1.0.1,<3.0

--- a/requirements/test-project.txt
+++ b/requirements/test-project.txt
@@ -4,4 +4,4 @@ cchardet
 backrefs>=3.5.2,<4.0
 bracex
 regex
-wcmatch>=1.0.1,<2.0
+wcmatch>=1.0.1,<3.0

--- a/rummage/lib/__version__.py
+++ b/rummage/lib/__version__.py
@@ -1,7 +1,7 @@
 """Version."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (4, 2, 3, 'final', 0, 0)
+version_info = (4, 2, 4, 'final', 0, 0)
 
 
 def _version():

--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -1321,17 +1321,17 @@ class Rummage(object):
         # Wcmatch flags
         self.wcmatch_flags = wcmatch.I | wcmatch.M | wcmatch.R
         if self.file_flags & EXTMATCH:
-            self.wcmatch_flags |= wcmatch.EXTGLOB
+            self.wcmatch_flags |= wcmatch.E
         if self.file_flags & BRACE:
-            self.wcmatch_flags |= wcmatch.BRACE
+            self.wcmatch_flags |= wcmatch.B
         if self.file_flags & FILECASE:
-            self.wcmatch_flags |= wcmatch.FORCECASE
+            self.wcmatch_flags |= wcmatch.F
         if self.file_flags & DIRPATHNAME:
-            self.wcmatch_flags |= wcmatch.DIRPATHNAME
+            self.wcmatch_flags |= wcmatch.DP
         if self.file_flags & FILEPATHNAME:
-            self.wcmatch_flags |= wcmatch.FILEPATHNAME
+            self.wcmatch_flags |= wcmatch.FP
         if self.file_flags & GLOBSTAR:
-            self.wcmatch_flags |= wcmatch.GLOBSTAR
+            self.wcmatch_flags |= wcmatch.G
 
         self.context = context
         self.encoding = self._verify_encoding(encoding) if encoding is not None else None


### PR DESCRIPTION
Use the appropriate flags as the flags changed for 2.0. We'll use the short form which actually work for pre 2.0 version as well. Ref #271 