### PR TITLE
Allow backrefs 4 moving forward

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,10 +1,10 @@
 gntp>=1.0.2
 chardet>=3.0.4
-backrefs>=3.5.2,<4.0
+wcmatch>=1.0.1,<3.0
+backrefs>=3.5.2,<5.0
 bracex
 wxpython>=4.0.1
 filelock
 send2trash
-wcmatch>=1.0.1,<3.0
 pymdown-extensions
 pygments


### PR DESCRIPTION
Backrefs 4 drops Python 2.7 support, something that isn't a problem for the Python 3 only Rummage branch.