### PR TITLE
No need to "kill" DirWalker

### DIFF
--- a/rummage/lib/rumcore/__init__.py
+++ b/rummage/lib/rumcore/__init__.py
@@ -1466,8 +1466,6 @@ class Rummage(object):
         self.abort = True
         if self.searcher:
             self.searcher.kill()
-        if self.path_walker:
-            self.path_walker.kill()
 
     def _get_next_file(self):
         """Get the next file from the file crawler results."""
@@ -1524,7 +1522,7 @@ class Rummage(object):
                 self.files.append(f)
 
             if self.abort:
-                self.files.clear()
+                break
 
             if len(self.files) >= folder_limit:
                 count = folder_limit
@@ -1581,6 +1579,8 @@ class Rummage(object):
                     if isinstance(f, FileAttrRecord) and f.skipped:
                         self.skipped += 1
                     yield f
+                    if self.abort:
+                        break
 
                 if self.abort:
                     self.files.clear()


### PR DESCRIPTION
We don't need to "kill" DirWalker. We can use a simple break.
Originally, before we split out the logic into wcmatch, we were using
this class differently. There really is no reason to kill it as it
shouldn't have anything we want to process when we see the abort.
Additionally, in the future, I will remove the "kill" nonsense from the
WcMatch class.