### PR TITLE
Linux tab interface color fix

### DIFF
--- a/rummage/lib/gui/dialogs/rummage_dialog.py
+++ b/rummage/lib/gui/dialogs/rummage_dialog.py
@@ -408,13 +408,17 @@ class RummageFrame(gui.RummageFrame):
         self.m_result_list.load_list(True)
         for x in range(self.m_grep_notebook.GetPageCount()):
             page = self.m_grep_notebook.GetPage(x)
-            bg = page.GetBackgroundColour()
+            if util.platform() == "linux":
+                bg = self.m_grep_notebook.GetBackgroundColour()
+            else:
+                bg = page.GetBackgroundColour()
             if util.platform() == "macos":
                 factor = 94 if data.RGBA(util.to_rgb(bg.GetRGB())).get_luminance() > 127 else 106
                 bg = bg.ChangeLightness(factor)
             page.SetBackgroundColour(bg)
             if x == 0:
-                self.m_grep_notebook.SetBackgroundColour(wx.Colour(bg))
+                if util.platform() != "linux":
+                    self.m_grep_notebook.SetBackgroundColour(wx.Colour(bg))
                 self.m_options_collapse.SetBackgroundColour(wx.Colour(bg))
                 self.m_limit_collapse.SetBackgroundColour(wx.Colour(bg))
         self.m_grep_notebook.SetSelection(0)

--- a/rummage/lib/gui/dialogs/settings_dialog.py
+++ b/rummage/lib/gui/dialogs/settings_dialog.py
@@ -76,17 +76,17 @@ class SettingsDialog(webview.WebViewMixin, gui.SettingsDialog):
 
         self.m_encoding_list.Bind(wx.EVT_LEFT_DCLICK, self.on_dclick)
 
-        if util.platform() == "windows":
-            self.m_settings_notebook.SetBackgroundColour(self.m_settings_panel.GetBackgroundColour())
-
         for x in range(self.m_settings_notebook.GetPageCount()):
             page = self.m_settings_notebook.GetPage(x)
-            bg = page.GetBackgroundColour()
+            if util.platform() == "linux":
+                bg = self.m_settings_notebook.GetBackgroundColour()
+            else:
+                bg = page.GetBackgroundColour()
             if util.platform() == "macos":
                 factor = 94 if data.RGBA(util.to_rgb(bg.GetRGB())).get_luminance() > 127 else 106
                 bg = bg.ChangeLightness(factor)
             page.SetBackgroundColour(bg)
-            if x == 0:
+            if x == 0 and util.platform() != "linux":
                 self.m_settings_notebook.SetBackgroundColour(wx.Colour(bg))
 
         self.localize()


### PR DESCRIPTION
Linux should not use the page background to paint the tab control and
collapsible controls, but instead should use the tab control. Colors are
not always reported exactly as they actually appear, so we will acquire
the default panel color in Linux and just use it for the tabbed
interface.