### PR TITLE
Ensure preferences is sized correctly on Linux

### DIFF
--- a/rummage/lib/gui/controls/webview.py
+++ b/rummage/lib/gui/controls/webview.py
@@ -252,7 +252,7 @@ class WebViewMixin:
 
         # Setup events
         obj.Bind(wx.html2.EVT_WEBVIEW_NAVIGATING, functools.partial(self.on_navigate, obj=obj))
-        obj.Bind(wx.html2.EVT_WEBVIEW_LOADED, functools.partial(self.on_loaded, obj=obj))
+        obj.Bind(wx.html2.EVT_WEBVIEW_LOADED, functools.partial(self.on_html_loaded, obj=obj))
         obj.Bind(wx.html2.EVT_WEBVIEW_TITLE_CHANGED, functools.partial(self.on_title_changed, obj=obj))
 
     def load_html(self, obj, content, title, content_type):
@@ -322,7 +322,7 @@ class WebViewMixin:
             title = obj.CurrentTitle
             obj.control_title.SetTitle(title)
 
-    def on_loaded(self, event, obj=None):
+    def on_html_loaded(self, event, obj=None):
         """Handle loaded event."""
 
         obj.busy = False

--- a/rummage/lib/gui/dialogs/checksum_dialog.py
+++ b/rummage/lib/gui/dialogs/checksum_dialog.py
@@ -51,6 +51,7 @@ class ChecksumDialog(gui.ChecksumDialog):
         self.m_hash_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
         self.total = os.path.getsize(self.target)
         self.start_hash()

--- a/rummage/lib/gui/dialogs/column_dialog.py
+++ b/rummage/lib/gui/dialogs/column_dialog.py
@@ -42,6 +42,7 @@ class ColumnDialog(gui.ColumnDialog):
         self.m_column_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
         self.m_column_list.SetFocus()
         self.changed = False

--- a/rummage/lib/gui/dialogs/delete_dialog.py
+++ b/rummage/lib/gui/dialogs/delete_dialog.py
@@ -143,6 +143,7 @@ class DeleteDialog(gui.DeleteDialog):
         self.m_progress_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
         self.start_delete()
 

--- a/rummage/lib/gui/dialogs/edit_search_chain_dialog.py
+++ b/rummage/lib/gui/dialogs/edit_search_chain_dialog.py
@@ -54,6 +54,7 @@ class EditSearchChainDialog(gui.EditSearchChainDialog):
         self.m_chain_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/error_text_dialog.py
+++ b/rummage/lib/gui/dialogs/error_text_dialog.py
@@ -35,6 +35,7 @@ class ErrorTextDialog(gui.ErrorTextDialog):
 
         self.m_error_text_panel.Fit()
         self.Fit()
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/export_settings_dialog.py
+++ b/rummage/lib/gui/dialogs/export_settings_dialog.py
@@ -40,6 +40,7 @@ class ExportSettingsDialog(gui.ExportSettingsDialog):
         self.m_export_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/file_ext_dialog.py
+++ b/rummage/lib/gui/dialogs/file_ext_dialog.py
@@ -44,6 +44,7 @@ class FileExtDialog(gui.FileExtDialog):
             self.SetSize(wx.Size(500, self.GetSize()[1]))
         self.SetMinSize(wx.Size(500, self.GetSize()[1]))
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/html_dialog.py
+++ b/rummage/lib/gui/dialogs/html_dialog.py
@@ -39,7 +39,7 @@ class HTMLDialog(gui.HtmlDialog, webview.WebViewMixin):
         self.localize()
         self.load(content, title, content_type)
         self.Fit()
-        self.Center()
+        self.Centre()
 
     def load(self, content, title=None, content_type=webview.HTML_FILE):
         """Reshow the dialog."""

--- a/rummage/lib/gui/dialogs/import_settings_dialog.py
+++ b/rummage/lib/gui/dialogs/import_settings_dialog.py
@@ -67,6 +67,7 @@ class ImportSettingsDialog(gui.ImportSettingsDialog):
         self.m_import_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
         self.chain_remember = False
         self.chain_action = False

--- a/rummage/lib/gui/dialogs/load_search_dialog.py
+++ b/rummage/lib/gui/dialogs/load_search_dialog.py
@@ -42,6 +42,7 @@ class LoadSearchDialog(gui.LoadSearchDialog):
         self.m_load_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
         self.load_searches()
         self.m_search_list.SetFocus()

--- a/rummage/lib/gui/dialogs/overwrite_dialog.py
+++ b/rummage/lib/gui/dialogs/overwrite_dialog.py
@@ -58,6 +58,7 @@ class OverwriteDialog(gui.OverwriteDialog):
         self.m_overwrite_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
     def localize(self, msg):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/regex_test_dialog.py
+++ b/rummage/lib/gui/dialogs/regex_test_dialog.py
@@ -166,6 +166,7 @@ class RegexTestDialog(gui.RegexTestDialog):
         self.m_tester_panel.Fit()
         self.Fit()
         self.SetMinSize(self.GetSize())
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/rummage_dialog.py
+++ b/rummage/lib/gui/dialogs/rummage_dialog.py
@@ -446,7 +446,8 @@ class RummageFrame(gui.RummageFrame):
         # now won't work, so we delay it.
         refocus = util.platform() == 'macos'
         resize = util.platform() == 'linux'
-        self.call_later = wx.CallLater(500, functools.partial(self.on_loaded, refocus=refocus, resize=resize))
+        delay = 500 if util.platform() == 'macos' else 100
+        self.call_later = wx.CallLater(delay, functools.partial(self.on_loaded, refocus=refocus, resize=resize))
         self.call_later.Start()
 
     def localize(self):

--- a/rummage/lib/gui/dialogs/rummage_dialog.py
+++ b/rummage/lib/gui/dialogs/rummage_dialog.py
@@ -1854,12 +1854,22 @@ class RummageFrame(gui.RummageFrame):
                 )
             )
 
+        reclose = False
+        if self.m_options_collapse.IsCollapsed():
+            self.m_options_collapse.Collapse(False)
+            reclose = True
+
         self.Fit()
         self.m_settings_panel.Fit()
         self.m_settings_panel.GetSizer().Layout()
         self.m_main_panel.Fit()
         self.m_main_panel.GetSizer().Layout()
+
+        if reclose:
+            self.m_options_collapse.Collapse(True)
+
         self.optimize_size(first_time=True)
+        self.Centre()
 
     def on_loaded(self, refocus=False, resize=False):
         """

--- a/rummage/lib/gui/dialogs/save_search_dialog.py
+++ b/rummage/lib/gui/dialogs/save_search_dialog.py
@@ -61,6 +61,7 @@ class SaveSearchDialog(gui.SaveSearchDialog):
         self.SetMinSize(self.GetSize())
         self.SetMaxSize(wx.Size(-1, self.GetSize()[1]))
         self.m_name_text.SetFocus()
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/search_chain_dialog.py
+++ b/rummage/lib/gui/dialogs/search_chain_dialog.py
@@ -44,6 +44,7 @@ class SearchChainDialog(gui.SearchChainDialog):
 
         self.load_chains()
         self.m_chain_list.SetFocus()
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/search_error_dialog.py
+++ b/rummage/lib/gui/dialogs/search_error_dialog.py
@@ -41,6 +41,7 @@ class SearchErrorDialog(gui.SearchErrorDialog):
         self.SetMinSize(self.GetSize())
         self.load_errors(errors)
         self.m_error_list.SetFocus()
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/settings_dialog.py
+++ b/rummage/lib/gui/dialogs/settings_dialog.py
@@ -199,10 +199,14 @@ class SettingsDialog(webview.WebViewMixin, gui.SettingsDialog):
         self.m_settings_notebook.Fit()
         self.m_settings_panel.Fit()
         self.Fit()
-        min_width = 550
+        max_width = self.GetParent().GetMinSize()[0]
+        min_width = 600
         if self.GetSize()[0] < min_width:
             self.SetSize(wx.Size(min_width, self.GetSize()[1]))
+        elif self.GetSize()[0] > max_width:
+            self.SetSize(wx.Size(max_width, self.GetSize()[1]))
         self.SetMinSize(wx.Size(min_width, self.GetSize()[1]))
+        self.Centre()
 
     def localize(self):
         """Translate strings."""

--- a/rummage/lib/gui/dialogs/support_info_dialog.py
+++ b/rummage/lib/gui/dialogs/support_info_dialog.py
@@ -70,6 +70,7 @@ class SupportInfoDialog(gui.SupportInfoDialog):
         self.SetMinSize(wx.Size(300, self.GetSize()[1]))
 
         self.display_support_information()
+        self.Centre()
 
     def localize(self):
         """Translate strings."""


### PR DESCRIPTION
Linux, when dealing with a tabbed interface, won't resize and refresh
controls correctly until after the window is loaded, so create an
on_loaded event for the preference window, and force a proper resize
then, but only for Linux.