### PR TITLE
Fix windows taskbar with a windows specific approach

### DIFF
--- a/rummage/lib/gui/app/rummage_app.py
+++ b/rummage/lib/gui/app/rummage_app.py
@@ -24,6 +24,7 @@ from .custom_app import PipeApp
 from ..dialogs import rummage_dialog
 from ..settings import Settings
 import wx
+from .. import util
 
 __all__ = ('RummageApp',)
 
@@ -33,6 +34,11 @@ class RummageApp(PipeApp):
 
     def __init__(self, argv, **kwargs):
         """Initialize Rummage app object."""
+
+        if util.platform() == "windows":
+            import ctypes
+
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('facelessuser.rummage.app.version')
 
         self.debug_mode = argv.debug
         self.path = argv.path if argv.path is not None else None

--- a/rummage/lib/gui/dialogs/rummage_dialog.py
+++ b/rummage/lib/gui/dialogs/rummage_dialog.py
@@ -340,7 +340,7 @@ class RummageFrame(gui.RummageFrame):
             data.get_image('rummage_large.png').GetIcon()
         )
 
-        if util.platform() != "linux":
+        if util.platform() == "macos":
             self.tbicon = TaskBarIcon(self, "Rummage", data.get_image('rummage_large.png').GetIcon())
 
         self.encodings = util.get_encodings()
@@ -2231,7 +2231,7 @@ class RummageFrame(gui.RummageFrame):
         self.m_result_file_list.destroy()
         self.m_statusbar.tear_down()
         notify.destroy_notifications()
-        if util.platform() != "linux":
+        if util.platform() == "macos":
             self.tbicon.Destroy()
         event.Skip()
 


### PR DESCRIPTION
Don't use the macOS dock technique to get the proper Windows taskbar
icon, but set the windows app id so the current frame icon will now
be used.

Closes #397 