### PR TITLE
Setting background color of ListCtrl on macOS causes white scroll square

### DIFF
--- a/rummage/lib/gui/controls/dynamic_lists.py
+++ b/rummage/lib/gui/controls/dynamic_lists.py
@@ -102,7 +102,6 @@ class DynamicList(wx.ListCtrl, listmix.ColumnSorterMixin):
     def update_colors(self):
         """Update colors."""
 
-        self.SetBackgroundColour(wx.NullColour)
         bg = rgba.RGBA(self.GetBackgroundColour().Get())
         factor = 0.93 if bg.get_luminance() >= 127 else 1.07
         if Settings.get_alt_list_color():


### PR DESCRIPTION
The square where the horz and vert scrollbar meet becomes white on macOS
if background gets set (to any color). Just read the color and calculate
the alt list color, no need to set background to wx.NullColour.